### PR TITLE
지도 API 연동

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set client .env
         run: |
           cd client
-          rm .env
+          rm -f .env
           echo "VITE_APP_NAVER_MAP_CLIENTID=${{ secrets.VITE_APP_NAVER_MAP_CLIENTID }}" >> .env
 
   # push 의 타겟 브랜치가 main 일 때 작동하는 job
@@ -60,5 +60,5 @@ jobs:
       - name: Set client .env
         run: |
           cd client
-          rm .env
+          rm -f .env
           echo "VITE_APP_NAVER_MAP_CLIENTID=${{ secrets.VITE_APP_NAVER_MAP_CLIENTID }}" >> .env

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,12 +1,12 @@
 name: Auto Deployment
 
-on: 
+on:
   push:
     # prod, release 브랜치에 push 시 작동
     branches:
       - prod
       - release
-    
+
 jobs:
   # push 의 타겟 브랜치가 release 일 때 작동하는 job
   deploy_release:
@@ -30,11 +30,17 @@ jobs:
             cd ../server
             npm ci
 
+      - name: Set client .env
+        run: |
+          cd client
+          rm .env
+          echo "VITE_APP_NAVER_MAP_CLIENTID=${{ secrets.VITE_APP_NAVER_MAP_CLIENTID }}" >> .env
+
   # push 의 타겟 브랜치가 main 일 때 작동하는 job
   deploy_prod:
     if: contains(github.ref, 'prod')
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: sshConnection
         uses: appleboy/ssh-action@master
@@ -50,3 +56,9 @@ jobs:
             npm ci
             cd ../server
             npm ci
+
+      - name: Set client .env
+        run: |
+          cd client
+          rm .env
+          echo "VITE_APP_NAVER_MAP_CLIENTID=${{ secrets.VITE_APP_NAVER_MAP_CLIENTID }}" >> .env

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: sshConnection
+      - name: sshAction
         # with 의 정보와 함께 원격 접속 수행
         uses: appleboy/ssh-action@master
         with:
@@ -26,15 +26,11 @@ jobs:
             git checkout release
             git pull origin release
             cd client
+            rm -f .env
+            echo "VITE_APP_NAVER_MAP_CLIENTID=${{ secrets.VITE_APP_NAVER_MAP_CLIENTID }}" >> .env
             npm ci
             cd ../server
             npm ci
-
-      - name: Set client .env
-        run: |
-          cd client
-          rm -f .env
-          echo "VITE_APP_NAVER_MAP_CLIENTID=${{ secrets.VITE_APP_NAVER_MAP_CLIENTID }}" >> .env
 
   # push 의 타겟 브랜치가 main 일 때 작동하는 job
   deploy_prod:
@@ -42,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: sshConnection
+      - name: sshAction
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.PROD_HOST }}
@@ -53,12 +49,8 @@ jobs:
             git checkout prod
             git pull origin prod
             cd client
+            rm -f .env
+            echo "VITE_APP_NAVER_MAP_CLIENTID=${{ secrets.VITE_APP_NAVER_MAP_CLIENTID }}" >> .env
             npm ci
             cd ../server
             npm ci
-
-      - name: Set client .env
-        run: |
-          cd client
-          rm -f .env
-          echo "VITE_APP_NAVER_MAP_CLIENTID=${{ secrets.VITE_APP_NAVER_MAP_CLIENTID }}" >> .env

--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -29,6 +29,12 @@ jobs:
           cd server
           npm ci
 
+      - name: Set client .env
+        run: |
+          cd client
+          rm .env
+          echo "VITE_APP_NAVER_MAP_CLIENTID=${{ secrets.VITE_APP_NAVER_MAP_CLIENTID }}" >> .env
+
       - name: Run client build
         run: |
           cd client

--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Set client .env
         run: |
           cd client
-          rm .env
           echo "VITE_APP_NAVER_MAP_CLIENTID=${{ secrets.VITE_APP_NAVER_MAP_CLIENTID }}" >> .env
 
       - name: Run client build

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -5,6 +5,7 @@
   "rules": {
     "prettier/prettier": 0,
     "import/no-unresolved": "off",
+    "import/prefer-default-export": "off",
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
     "react/jsx-filename-extension": ["warn", { "extensions": [".ts", ".tsx"] }],

--- a/client/index.html
+++ b/client/index.html
@@ -9,5 +9,9 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script
+      type="text/javascript"
+      src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=<{VITE_APP_NAVER_MAP_CLIENTID}>"
+    ></script>
   </body>
 </html>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,7 @@
         "vite-plugin-html-env": "^1.2.7"
       },
       "devDependencies": {
+        "@types/node": "^18.11.9",
         "@types/react": "^18.0.24",
         "@types/react-dom": "^18.0.8",
         "@types/styled-components": "^5.1.26",
@@ -950,6 +951,12 @@
       "dependencies": {
         "@types/geojson": "*"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+      "dev": true
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -5337,6 +5344,12 @@
       "requires": {
         "@types/geojson": "*"
       }
+    },
+    "@types/node": {
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+      "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,10 +8,12 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@types/navermaps": "^3.6.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.3",
-        "styled-components": "^5.3.6"
+        "styled-components": "^5.3.6",
+        "vite-plugin-html-env": "^1.2.7"
       },
       "devDependencies": {
         "@types/react": "^18.0.24",
@@ -34,7 +36,7 @@
         "vite-plugin-svgr": "^2.2.2"
       },
       "engines": {
-        "node": ">=16.18.1"
+        "node": ">=16.0.0 <17.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -914,6 +916,11 @@
       "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "dev": true
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -935,6 +942,14 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/navermaps": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@types/navermaps/-/navermaps-3.6.1.tgz",
+      "integrity": "sha512-pYD2iPD1+WYiJI5A241H57Vv+Upnuo9W3Tm9PIdxYXVD3pkVyBFFGFK+4wANt8weG/3Us5x5a4FeIDgb07sBPg==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -4615,6 +4630,17 @@
         }
       }
     },
+    "node_modules/vite-plugin-html-env": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vite-plugin-html-env/-/vite-plugin-html-env-1.2.7.tgz",
+      "integrity": "sha512-vdTnKtuBeB8Zp93DCbN0Qjf4odW2msVRq45r7lGKA6nwQGJFj6YemU54u3xPPkvDeZhG8DEEU64xbLwzVEBilQ==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
     "node_modules/vite-plugin-svgr": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-2.2.2.tgz",
@@ -5176,57 +5202,49 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.5.1.tgz",
       "integrity": "sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.5.0.tgz",
       "integrity": "sha512-8zYdkym7qNyfXpWvu4yq46k41pyNM9SOstoWhKlm+IfdCE1DdnRKeMUPsWIEO/DEkaWxJ8T9esNdG3QwQ93jBA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.5.0.tgz",
       "integrity": "sha512-NFdxMq3xA42Kb1UbzCVxplUc0iqSyM9X8kopImvFnB+uSDdzIHOdbs1op8ofAvVRtbg4oZiyRl3fTYeKcOe9Iw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.5.1.tgz",
       "integrity": "sha512-8DPaVVE3fd5JKuIC29dqyMB54sA6mfgki2H2+swh+zNJoynC8pMPzOkidqHOSc6Wj032fhl8Z0TVn1GiPpAiJg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.5.1.tgz",
       "integrity": "sha512-FwOEi0Il72iAzlkaHrlemVurgSQRDFbk0OC8dSvD5fSBPHltNh7JtLsxmZUhjYBZo2PpcU/RJvvi6Q0l7O7ogw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.5.1.tgz",
       "integrity": "sha512-gWGsiwjb4tw+ITOJ86ndY/DZZ6cuXMNE/SjcDRg+HLuCmwpcjOktwRF9WgAiycTqJD/QXqL2f8IzE2Rzh7aVXA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.5.1.tgz",
       "integrity": "sha512-2jT3nTayyYP7kI6aGutkyfJ7UMGtuguD72OjeGLwVNyfPRBD8zQthlvL+fAbAKk5n9ZNcvFkp/b1lZ7VsYqVJg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.5.1.tgz",
       "integrity": "sha512-a1p6LF5Jt33O3rZoVRBqdxL350oge54iZWHNI6LJB5tQ7EelvD/Mb1mfBiZNAan0dt4i3VArkFRjA4iObuNykQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-preset": {
       "version": "6.5.1",
@@ -5285,6 +5303,11 @@
       "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "dev": true
     },
+    "@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -5306,6 +5329,14 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "@types/navermaps": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@types/navermaps/-/navermaps-3.6.1.tgz",
+      "integrity": "sha512-pYD2iPD1+WYiJI5A241H57Vv+Upnuo9W3Tm9PIdxYXVD3pkVyBFFGFK+4wANt8weG/3Us5x5a4FeIDgb07sBPg==",
+      "requires": {
+        "@types/geojson": "*"
+      }
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -5534,8 +5565,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -6267,8 +6297,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -6436,8 +6465,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.1.1",
@@ -7818,6 +7846,11 @@
         "resolve": "^1.22.1",
         "rollup": "^2.79.1"
       }
+    },
+    "vite-plugin-html-env": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vite-plugin-html-env/-/vite-plugin-html-env-1.2.7.tgz",
+      "integrity": "sha512-vdTnKtuBeB8Zp93DCbN0Qjf4odW2msVRq45r7lGKA6nwQGJFj6YemU54u3xPPkvDeZhG8DEEU64xbLwzVEBilQ=="
     },
     "vite-plugin-svgr": {
       "version": "2.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,9 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",
     "styled-components": "^5.3.6",
+    "vite": "^3.2.3",
+    "vite-plugin-svgr": "^2.2.2",
+    "@vitejs/plugin-react": "^2.2.0",
     "vite-plugin-html-env": "^1.2.7"
   },
   "devDependencies": {
@@ -23,7 +26,6 @@
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
-    "@vitejs/plugin-react": "^2.2.0",
     "eslint": "^8.27.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
@@ -33,9 +35,7 @@
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^2.7.1",
-    "typescript": "^4.6.4",
-    "vite": "^3.2.3",
-    "vite-plugin-svgr": "^2.2.2"
+    "typescript": "^4.6.4"
   },
   "engines": {
     "node": ">=16.0.0 <17.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "vite-plugin-html-env": "^1.2.7"
   },
   "devDependencies": {
+    "@types/node": "^18.11.9",
     "@types/react": "^18.0.24",
     "@types/react-dom": "^18.0.8",
     "@types/styled-components": "^5.1.26",

--- a/client/package.json
+++ b/client/package.json
@@ -9,10 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/navermaps": "^3.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",
-    "styled-components": "^5.3.6"
+    "styled-components": "^5.3.6",
+    "vite-plugin-html-env": "^1.2.7"
   },
   "devDependencies": {
     "@types/react": "^18.0.24",

--- a/client/src/Router.tsx
+++ b/client/src/Router.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import GlobalStyle, { MainLayout } from '@styles/GlobalStyle';
 import HomePage from '@pages/HomePage';
+import InitRoomPage from '@pages/InitRoomPage';
 
 function Router() {
   return (
@@ -10,7 +11,7 @@ function Router() {
 
         <Routes>
           <Route path="/" element={<HomePage />} />
-          <Route path="/init-room" element={<div /> /* <InitRoomPage /> */} />
+          <Route path="/init-room" element={<InitRoomPage />} />
         </Routes>
       </MainLayout>
     </BrowserRouter>

--- a/client/src/pages/InitRoomPage/index.tsx
+++ b/client/src/pages/InitRoomPage/index.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react';
+import { InitRoomPageLayout } from '@pages/InitRoomPage/styles';
+
+function InitRoomPage() {
+  const mapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const initMap = () => {
+      if (!mapRef.current) return;
+
+      const map = new naver.maps.Map(mapRef.current, {
+        // TODO: 지도 시작 좌표를 추후 사용자 위치로 변경
+        center: new naver.maps.LatLng(37.5, 127.039573),
+        zoom: 14,
+      });
+
+      const marker = new naver.maps.Marker({
+        // TODO: 마커 좌표를 추후 사용자 위치로 변경
+        position: new naver.maps.LatLng(37.5, 127.039573),
+        map,
+      });
+    };
+
+    initMap();
+  }, []);
+
+  return <InitRoomPageLayout id="map" ref={mapRef} />;
+}
+
+export default InitRoomPage;

--- a/client/src/pages/InitRoomPage/styles.tsx
+++ b/client/src/pages/InitRoomPage/styles.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 
-// eslint-disable-next-line import/prefer-default-export
 export const InitRoomPageLayout = styled.div`
   width: 100%;
   height: 100%;

--- a/client/src/pages/InitRoomPage/styles.tsx
+++ b/client/src/pages/InitRoomPage/styles.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+// eslint-disable-next-line import/prefer-default-export
+export const InitRoomPageLayout = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,10 +2,11 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 import svgr from 'vite-plugin-svgr';
+import VitePluginHtmlEnv from 'vite-plugin-html-env';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), svgr()],
+  plugins: [react(), svgr(), VitePluginHtmlEnv()],
   resolve: {
     alias: {
       '@assets': resolve(__dirname, 'src/assets'),

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -18,5 +18,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'import/prefer-default-export': 'off',
   },
 };


### PR DESCRIPTION
## 링크(관련 이슈)
#12 
<br>

## 개요
- 지도 API 연동 작업과 지도 API 관련 환경 변수 설정
- 오전 회의에서 나온 자잘한 eslint, 모듈 관련 작업 처리

<br>

## 내용
### 지도 관련 작업
- 지도 API 조사 및 선택
- `InitRoomPage`에 지도 연동
- 깃허브 Secrets에 네이버 지도 Client ID 추가(`VITE_APP_NAVER_MAP_CLIENTID`)
- CI/CD 파일에 .env 세팅하는 코드 추가

### 기타
- eslint `prefer-default-export` 옵션 OFF
- `@types/node` 모듈 설치(Cannot find name '__dirname' 문제 해결)
- Vite 관련 모듈 devDependencies -> dependencies로 이동 (eslint 빨간줄 해결을 위해)

<br>

## 비고
- 추후 지도는 컴포넌트로 분리할 예정입니다.
- 지도 API 연동, 환경변수 관련 내용은 개발 노트에 추가하겠습니다.
- 실행 화면
<img width="250" alt="Init Room Page" src="https://user-images.githubusercontent.com/55318618/203239082-00805c4a-168a-4944-ab7b-fb5491b02386.png">

<br>

## 리뷰어한테 할 말
1. 로컬 환경에서 `client` 폴더 하위에 `.env` 파일을 생성하시고 
`VITE_APP_NAVER_MAP_CLIENTID` 환경 변수 값을 넣어서 지도가 잘 나오는지 확인 부탁드립니다.

2. CI/CD쪽 코드를 집중적으로 봐주시면 감사하겠습니다,,