### PR TITLE
좌표 정보 도로명 주소 변환 API

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { RoomModule } from '@room/room.module';
 import { RestaurantModule } from '@restaurant/restaurant.module';
+import { MapModule } from '@map/map.module';
 import * as Joi from 'joi';
 
 @Module({
@@ -16,6 +17,8 @@ import * as Joi from 'joi';
         MONGODB_PASSWORD: Joi.string().required(),
         MONGODB_DB_NAME: Joi.string().required(),
         KAKAO_API_KEY: Joi.string().required(),
+        NAVER_MAP_CLIENT_ID: Joi.string().required(),
+        NAVER_MAP_CLIENT_SECRET: Joi.string().required(),
       }),
     }),
     MongooseModule.forRootAsync({
@@ -29,6 +32,7 @@ import * as Joi from 'joi';
       inject: [ConfigService],
     }),
     RoomModule,
+    MapModule,
   ],
   controllers: [],
   providers: [],

--- a/server/src/constants/api.ts
+++ b/server/src/constants/api.ts
@@ -1,0 +1,2 @@
+export const REVERSE_GEOCODE_API_URL =
+  'https://naveropenapi.apigw.ntruss.com/map-reversegeocode/v2/gc';

--- a/server/src/map/dto/get-reverse-geocode.ts
+++ b/server/src/map/dto/get-reverse-geocode.ts
@@ -1,0 +1,12 @@
+import { Transform } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+export class GetReverseGeocodeDto {
+  @Transform(({ value }) => Number(value))
+  @IsNumber()
+  lat: number;
+
+  @Transform(({ value }) => Number(value))
+  @IsNumber()
+  lng: number;
+}

--- a/server/src/map/map.controller.ts
+++ b/server/src/map/map.controller.ts
@@ -6,7 +6,7 @@ import { GetReverseGeocodeDto } from '@map/dto/get-reverse-geocode';
 export class MapController {
   constructor(private readonly mapService: MapService) {}
 
-  @Get('/reversegeocode')
+  @Get('reversegeocode')
   async getReverseGeocode(@Query() getReverseGeocodeDto: GetReverseGeocodeDto) {
     const roadAddr = await this.mapService.reverseGeocode(
       getReverseGeocodeDto.lat,

--- a/server/src/map/map.controller.ts
+++ b/server/src/map/map.controller.ts
@@ -7,8 +7,11 @@ export class MapController {
   constructor(private readonly mapService: MapService) {}
 
   @Get('/reversegeocode')
-  async getReverseGeocode(@Query('lat') lat: number, @Query('lng') lng: number) {
-    const roadAddr = await this.mapService.reverseGeocode(lat, lng);
+  async getReverseGeocode(@Query() getReverseGeocodeDto: GetReverseGeocodeDto) {
+    const roadAddr = await this.mapService.reverseGeocode(
+      getReverseGeocodeDto.lat,
+      getReverseGeocodeDto.lng
+    );
     return { message: '성공적으로 주소를 변환했습니다.', data: { roadAddr } };
   }
 }

--- a/server/src/map/map.controller.ts
+++ b/server/src/map/map.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { MapService } from '@map/map.service';
+import { GetReverseGeocodeDto } from '@map/dto/get-reverse-geocode';
+
+@Controller('map')
+export class MapController {
+  constructor(private readonly mapService: MapService) {}
+
+  @Get('/reversegeocode')
+  async getReverseGeocode(@Query('lat') lat: number, @Query('lng') lng: number) {
+    const roadAddr = await this.mapService.reverseGeocode(lat, lng);
+    return { message: '성공적으로 주소를 변환했습니다.', data: { roadAddr } };
+  }
+}

--- a/server/src/map/map.d.ts
+++ b/server/src/map/map.d.ts
@@ -1,0 +1,27 @@
+interface areaType {
+  name: string; // 명칭
+}
+
+export interface regionType {
+  area1: areaType; // 행정안전부에서 공시된 시/도
+  area2: areaType; // 행정안전부에서 공시된 시/군/구 명칭
+}
+
+export interface landType {
+  number1: string; // 지번 주소인 경우 토지 본번호, 도로명 주소인 경우 상세주소
+  name: string; // 지번 주소인 경우 reserved, 도로명 주소인 경우 도로명
+}
+
+interface statusType {
+  code: number; // 코드 정보
+}
+
+interface resultType {
+  region: regionType; // 지역 명칭 정보
+  land: landType; // 상세주소 정보
+}
+
+export interface naverMapReverseGeocodeResType {
+  status: statusType;
+  results: resultType[];
+}

--- a/server/src/map/map.module.ts
+++ b/server/src/map/map.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MapController } from './map.controller';
+import { MapService } from './map.service';
+
+@Module({
+  controllers: [MapController],
+  providers: [MapService],
+})
+export class MapModule {}

--- a/server/src/map/map.service.ts
+++ b/server/src/map/map.service.ts
@@ -7,8 +7,8 @@ import { isInKorea } from '@utils/location';
 
 @Injectable()
 export class MapService {
-  NAVER_MAP_CLIENT_ID: string;
-  NAVER_MAP_CLIENT_SECRET: string;
+  private readonly NAVER_MAP_CLIENT_ID: string;
+  private readonly NAVER_MAP_CLIENT_SECRET: string;
 
   constructor(private readonly configService: ConfigService) {
     this.NAVER_MAP_CLIENT_ID = this.configService.get('NAVER_MAP_CLIENT_ID');

--- a/server/src/map/map.service.ts
+++ b/server/src/map/map.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { REVERSE_GEOCODE_API_URL } from '@constants/api';
+import { CustomException } from '@common/exceptions/custom.exception';
+import { isInKorea } from '@utils/location';
+
+@Injectable()
+export class MapService {
+  NAVER_MAP_CLIENT_ID: string;
+  NAVER_MAP_CLIENT_SECRET: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.NAVER_MAP_CLIENT_ID = this.configService.get('NAVER_MAP_CLIENT_ID');
+    this.NAVER_MAP_CLIENT_SECRET = this.configService.get('NAVER_MAP_CLIENT_SECRET');
+  }
+
+  /**
+   * 입력된 위도, 경도 데이터를 도로명 주소로 반환
+   */
+  async reverseGeocode(lat: number, lng: number) {
+    if (!isInKorea(lat, lng)) {
+      throw new CustomException('대한민국을 벗어난 입력입니다.');
+    }
+
+    const { region, land } = await this.getRegionAndLandData(lat, lng);
+    const roadAddr = this.combineRegionAndLandData(region, land); // 도로명 주소
+
+    return roadAddr;
+  }
+
+  /**
+   * Naver Maps의 Reverse geocoding API에 요청을 보내고, 응답 데이터를 반환
+   */
+  private async getRegionAndLandData(lat: number, lng: number) {
+    const position = `${lng},${lat}`;
+    try {
+      const { data } = await axios.get(REVERSE_GEOCODE_API_URL, {
+        headers: {
+          'X-NCP-APIGW-API-KEY-ID': this.NAVER_MAP_CLIENT_ID,
+          'X-NCP-APIGW-API-KEY': this.NAVER_MAP_CLIENT_SECRET,
+        },
+        params: { coords: position, output: 'json', orders: 'roadaddr' },
+      });
+
+      if (data?.status?.code !== 0) {
+        throw new Error(); // 성공적 응답이 아닌 경우
+      }
+      return data.results[0];
+    } catch (error) {
+      throw new CustomException('위치 좌표의 주소 변환 요청이 실패했습니다.');
+    }
+  }
+
+  /**
+   * region과 land 데이터를 조합하여 도로명 주소를 반환
+   */
+  private combineRegionAndLandData = (regionData: any, landData: any) => {
+    const { area1, area2 } = regionData;
+    const { name, number1 } = landData;
+
+    return [area1?.name, area2?.name, name, number1].filter((v) => v).join(' ');
+  };
+}

--- a/server/src/map/map.service.ts
+++ b/server/src/map/map.service.ts
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { REVERSE_GEOCODE_API_URL } from '@constants/api';
 import { CustomException } from '@common/exceptions/custom.exception';
 import { isInKorea } from '@utils/location';
+import { landType, naverMapReverseGeocodeResType, regionType } from '@map/map';
 
 @Injectable()
 export class MapService {
@@ -35,13 +36,15 @@ export class MapService {
   private async getRegionAndLandData(lat: number, lng: number) {
     const position = `${lng},${lat}`;
     try {
-      const { data } = await axios.get(REVERSE_GEOCODE_API_URL, {
+      const response = await axios.get(REVERSE_GEOCODE_API_URL, {
         headers: {
           'X-NCP-APIGW-API-KEY-ID': this.NAVER_MAP_CLIENT_ID,
           'X-NCP-APIGW-API-KEY': this.NAVER_MAP_CLIENT_SECRET,
         },
         params: { coords: position, output: 'json', orders: 'roadaddr' },
       });
+
+      const data: naverMapReverseGeocodeResType = response.data;
 
       if (data?.status?.code !== 0) {
         throw new Error(); // 성공적 응답이 아닌 경우
@@ -55,7 +58,7 @@ export class MapService {
   /**
    * region과 land 데이터를 조합하여 도로명 주소를 반환
    */
-  private combineRegionAndLandData = (regionData: any, landData: any) => {
+  private combineRegionAndLandData = (regionData: regionType, landData: landType) => {
     const { area1, area2 } = regionData;
     const { name, number1 } = landData;
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -16,6 +16,7 @@
       "@utils/*": ["./src/utils/*"],
       "@restaurant/*": ["./src/restaurant/*"],
       "@room/*": ["./src/room/*"],
+      "@map/*": ["./src/map/*"],
     },
     "incremental": true,
     "skipLibCheck": true,


### PR DESCRIPTION
### 프론트엔드에서 Naver Map의 submodule을 사용해서 진행(https://github.com/boostcampwm-2022/web08-ChoBab/issues/15 )하기로 결정되었습니다.

## 링크(관련 이슈)
#59 
<br>

## 개요
좌표 정보를 도로명 주소로 변환하는 API

<br>

## 내용
- map 폴더 Path alias 설정
- query 파라미터 dto 활용
- Naver Map Reverse geocoding API url constant 선언
- Naver Maps의 Reverse geocoding API를 활용해 좌표에 대한 주소 정보 가져오기
- 가져온 주소 정보 조합해서 도로명 주소로 변환

<br>

## 비고
- 개발 노트
  - [좌표 정보 → 주소 변환 Naver Maps API](https://delicious-guys.notion.site/Naver-Maps-API-620318d4bc7d4ee392da3292281f9731)
- query 파라미터를 dto로 사용하는 것은 [Nest JS Validate Query Paramater and DTOs](https://tkssharma.com/nestjs-playing-with-query-param-dto/) 사이트를 참고했습니다.

<br>

## 리뷰어한테 할 말
