### PR TITLE
Backend 응답/예외 관련 파일 분리

### DIFF
--- a/server/src/common/response/index.ts
+++ b/server/src/common/response/index.ts
@@ -1,0 +1,16 @@
+export interface SuccessResType {
+  message: string;
+  data: any;
+}
+
+export interface FailResType {
+  message: string;
+}
+
+export const successRes = (message: string, data: any): SuccessResType => {
+  return { message, data };
+};
+
+export const failRes = (message: string): FailResType => {
+  return { message };
+};

--- a/server/src/common/response/location.ts
+++ b/server/src/common/response/location.ts
@@ -1,7 +1,6 @@
 import { failRes } from './index';
 
-export const LOCATION_RES = {};
-
 export const LOCATION_EXCEPTION = {
   OUT_OF_KOREA: failRes('대한민국을 벗어난 입력입니다.'),
+  OUT_OF_MAX_RADIUS: failRes('최대 탐색 반경을 벗어난 입력입니다.'),
 };

--- a/server/src/common/response/location.ts
+++ b/server/src/common/response/location.ts
@@ -1,0 +1,7 @@
+import { failRes } from './index';
+
+export const LOCATION_RES = {};
+
+export const LOCATION_EXCEPTION = {
+  OUT_OF_KOREA: failRes('대한민국을 벗어난 입력입니다.'),
+};

--- a/server/src/common/response/restaurant.ts
+++ b/server/src/common/response/restaurant.ts
@@ -1,0 +1,1 @@
+export const RESTAURANT_EXCEPTION = {};

--- a/server/src/common/response/room.ts
+++ b/server/src/common/response/room.ts
@@ -1,0 +1,16 @@
+import { failRes, successRes } from './index';
+
+export const ROOM_RES = {
+  SUCCESS_CREATE_ROOM: (roomCode: string) => {
+    return successRes('성공적으로 모임방을 생성했습니다.', { roomCode });
+  },
+  SUCCESS_VALID_ROOM: successRes('유효한 roomCode입니다.', { isRoomValid: true }),
+};
+
+export const ROOM_EXCEPTION = {
+  FAIL_CREATE_ROOM: failRes('모임방 생성에 실패했습니다.'),
+  FAIL_VALID_ROOM: failRes('유효하지 않은 모임방입니다.'),
+  FAIL_SEARCH_ROOM: failRes('모임방 검색에 실패했습니다.'),
+  IS_NOT_EXIST_ROOM: failRes('존재하지 않는 모임방입니다.'),
+  ALREADY_DELETED_ROOM: failRes('이미 삭제된 모임방입니다.'),
+};

--- a/server/src/restaurant/restaurant.service.ts
+++ b/server/src/restaurant/restaurant.service.ts
@@ -6,6 +6,7 @@ import { isInKorea } from '@utils/location';
 import { originRestaurantType, preprocessedRestaurantType } from './restaurant';
 import { RESTAURANT_CATEGORY } from '@constants/restaurant';
 import { MAX_RADIUS } from '@constants/location';
+import { LOCATION_EXCEPTION } from '@response/location';
 
 interface restaurantApiResultType {
   meta: {
@@ -87,11 +88,11 @@ export class RestaurantService {
 
   async getRestaurantList(lat: number, lng: number, radius: number) {
     if (!isInKorea(lat, lng)) {
-      throw new CustomException('대한민국을 벗어난 입력입니다.');
+      throw new CustomException(LOCATION_EXCEPTION.OUT_OF_KOREA);
     }
 
     if (radius > MAX_RADIUS) {
-      throw new CustomException('최대 탐색 반경을 벗어난 입력입니다.');
+      throw new CustomException(LOCATION_EXCEPTION.OUT_OF_MAX_RADIUS);
     }
 
     const restaurantSet = new Set();
@@ -107,9 +108,6 @@ export class RestaurantService {
       });
     });
 
-    return {
-      message: '음식점을 성공적으로 불러왔습니다.',
-      data: Array.from(restaurantSet) as preprocessedRestaurantType[],
-    };
+    return Array.from(restaurantSet) as preprocessedRestaurantType[];
   }
 }

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -3,6 +3,7 @@ import { CreateRoomDto } from '@room/dto/create-room.dto';
 import { ResTemplate } from '@common/interceptors/template.interceptor';
 import { RoomService } from '@room/room.service';
 import { CustomException } from '@common/exceptions/custom.exception';
+import { ROOM_EXCEPTION, ROOM_RES } from '@response/room';
 
 @Controller('room')
 export class RoomController {
@@ -11,16 +12,16 @@ export class RoomController {
   @Post()
   async createRoom(@Body() createRoomDto: CreateRoomDto): Promise<ResTemplate<any>> {
     const roomCode = await this.roomService.createRoom(createRoomDto.lat, createRoomDto.lng);
-    return { message: '성공적으로 모임방을 생성했습니다.', data: { roomCode } };
+    return ROOM_RES.SUCCESS_CREATE_ROOM(roomCode);
   }
 
   @Get('valid')
   async validRoom(@Query('roomCode') roomCode: string) {
     const isRoomValid = await this.roomService.validRoom(roomCode);
     if (!isRoomValid) {
-      throw new CustomException('유효하지 않은 roomCode 입니다.');
+      throw new CustomException(ROOM_EXCEPTION.FAIL_VALID_ROOM);
     }
 
-    return { message: '유효한 roomCode 입니다.', data: { isRoomValid } };
+    return ROOM_RES.SUCCESS_VALID_ROOM;
   }
 }

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -5,6 +5,8 @@ import { Room, RoomDocument } from './room.schema';
 import { Model } from 'mongoose';
 import { CustomException } from '@common/exceptions/custom.exception';
 import { isInKorea } from '@utils/location';
+import { LOCATION_EXCEPTION } from '@response/location';
+import { ROOM_EXCEPTION } from '@response/room';
 
 @Injectable()
 export class RoomService {
@@ -12,7 +14,7 @@ export class RoomService {
 
   async createRoom(lat: number, lng: number): Promise<string> {
     if (!isInKorea(lat, lng)) {
-      throw new CustomException('대한민국을 벗어난 입력입니다.');
+      throw new CustomException(LOCATION_EXCEPTION.OUT_OF_KOREA);
     }
 
     try {
@@ -21,7 +23,7 @@ export class RoomService {
 
       return roomCode;
     } catch (error) {
-      throw new CustomException('모임방 생성에 실패했습니다.');
+      throw new CustomException(ROOM_EXCEPTION.FAIL_CREATE_ROOM);
     }
   }
 
@@ -33,7 +35,7 @@ export class RoomService {
       }
       return true;
     } catch (error) {
-      throw new CustomException('모임방 검색에 실패했습니다.');
+      throw new CustomException(ROOM_EXCEPTION.FAIL_SEARCH_ROOM);
     }
   }
 
@@ -41,14 +43,14 @@ export class RoomService {
     try {
       const room = await this.roomModel.findOne({ roomCode });
       if (!room) {
-        throw new CustomException('존재하지 않는 모임방입니다.');
+        throw new CustomException(ROOM_EXCEPTION.IS_NOT_EXIST_ROOM);
       }
       if (room.deletedAt) {
-        throw new CustomException('삭제된 모임방입니다.');
+        throw new CustomException(ROOM_EXCEPTION.ALREADY_DELETED_ROOM);
       }
       return { lat: room.lat, lng: room.lng };
     } catch (error) {
-      throw new CustomException('모임방 검색에 실패했습니다.');
+      throw new CustomException(ROOM_EXCEPTION.FAIL_SEARCH_ROOM);
     }
   }
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -16,6 +16,7 @@
       "@utils/*": ["./src/utils/*"],
       "@restaurant/*": ["./src/restaurant/*"],
       "@room/*": ["./src/room/*"],
+      "@response/*": ["./src/common/response/*"],
     },
     "incremental": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## 링크(관련 이슈)
#66 
<br>

## 개요
기존에 object 혹은 직접 문자열을 넣어주어 throw 하는 부분에 대해 응답/예외 관련된 것을 따로 파일로 분리해 변수 혹은 함수를 호출해서 사용하는 식으로 변경 

<br>

## 내용
- src/common 하위에 response 폴더 생성해서 작업
  - @response로 path alias로 설정
- room과 restaurant에 대한 응답/예외와 관련하여 변수 및 함수 생성
- room 도메인의 controller, service와 restaurant 도메인의 service에 적용

<br>

## 비고
![image](https://user-images.githubusercontent.com/74449232/204195713-bc23447f-6b39-4ea5-b121-1ae8a3e2cc02.png)
![image](https://user-images.githubusercontent.com/74449232/204195756-bd2f1cf1-6140-437e-8433-6c804b0a8f7e.png)


<br>

## 리뷰어한테 할 말
- restaurant.controller 쪽은 삭제되기로 한 부분이기 때문에 적용시키지 않았습니다!