### PR TITLE
모임 위치 검색 기능 - naver map 생성 로직 커스텀 훅으로 분리

### DIFF
--- a/client/src/components/MeetLocationSettingMap/index.tsx
+++ b/client/src/components/MeetLocationSettingMap/index.tsx
@@ -55,8 +55,6 @@ function MeetLocationSettingMap() {
     }
 
     updateMeetLocation(userLocation.lat, userLocation.lng);
-
-    mapRef.current.setCenter({ x: userLocation.lng, y: userLocation.lat });
   }, [userLocation]);
 
   // 모임 위치(전역 상태) 변경 시 지도 화면 이동

--- a/client/src/hooks/useNaverMaps.tsx
+++ b/client/src/hooks/useNaverMaps.tsx
@@ -1,0 +1,24 @@
+import { MutableRefObject, RefObject, useEffect, useRef } from 'react';
+import { NAVER_LAT, NAVER_LNG } from '@constants/map';
+
+// mutable ref object 와 ref object 의 차이는 뭐지?
+export const useNaverMaps = (): [
+  MutableRefObject<naver.maps.Map | null>,
+  RefObject<HTMLDivElement>
+] => {
+  const mapRef = useRef<naver.maps.Map | null>(null);
+  const mapDivRef = useRef<HTMLDivElement>(null); // type 에 null 포함시키면 사용이 불가,,
+
+  useEffect(() => {
+    if (!mapDivRef.current) {
+      return;
+    }
+
+    mapRef.current = new naver.maps.Map(mapDivRef.current, {
+      center: new naver.maps.LatLng(NAVER_LAT, NAVER_LNG),
+      zoom: 14,
+    });
+  }, []);
+
+  return [mapRef, mapDivRef];
+};

--- a/client/src/hooks/useNaverMaps.tsx
+++ b/client/src/hooks/useNaverMaps.tsx
@@ -1,13 +1,12 @@
 import { MutableRefObject, RefObject, useEffect, useRef } from 'react';
 import { NAVER_LAT, NAVER_LNG } from '@constants/map';
 
-// mutable ref object 와 ref object 의 차이는 뭐지?
 export const useNaverMaps = (): [
   MutableRefObject<naver.maps.Map | null>,
   RefObject<HTMLDivElement>
 ] => {
   const mapRef = useRef<naver.maps.Map | null>(null);
-  const mapDivRef = useRef<HTMLDivElement>(null); // type 에 null 포함시키면 사용이 불가,,
+  const mapDivRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!mapDivRef.current) {


### PR DESCRIPTION
## 링크(관련 ~이슈~)

#88 

<br>

## 개요

naver map 생성 로직 커스텀 훅으로 분리
(issue #16 기능에 대해 올라온 PR #88 에 대한 PR)

<br>

## 내용

사실 #16 이슈와는 무관한 리뷰 PR 입니다. (구현된 모임위치 검색기능에 대한 리뷰는 아닙니다.)
하지만 zustand 전역 상태를 도입하여 컴포넌트의 덩치가 조금은 커지면서 분리하면 좋을 것 같다는 로직이 보였고
이번 PR 에 처리하면 좋겠다싶어 리팩토링 관련해서 추가 PR 를 날립니다.

앞으로 구현 될 MainPage 에서도 사용 될 Naver Map 생성관련 로직을 커스텀 훅으로 분리하였습니다.
변경된 코드 읽어보시고 리뷰해주세요!

<br>

## 비고

<br>

## 리뷰어한테 할 말
