### PR TITLE
음식점 생성 시 DB 상에 음식점 상세정보가 함께 포함된 음식점 정보를 적재하도록 수정

### DIFF
--- a/client/src/pages/MainPage/index.tsx
+++ b/client/src/pages/MainPage/index.tsx
@@ -37,6 +37,10 @@ interface RestaurantType {
   lat: number;
   lng: number;
   address: string;
+  rating?: number;
+  photoUrlList?: string[];
+  openNow?: boolean;
+  priceLevel?: number;
 }
 
 interface ResTemplateType<T> {
@@ -86,7 +90,6 @@ function MainPage() {
         console.log(data.message);
         return;
       }
-
       const { lat, lng, userList, restaurantList, candidateList, userId, userName } = data.data;
 
       const tmp = new Map();

--- a/client/src/pages/MainPage/index.tsx
+++ b/client/src/pages/MainPage/index.tsx
@@ -39,7 +39,6 @@ interface RestaurantType {
   address: string;
   rating?: number;
   photoKeyList?: string[];
-  openNow?: boolean;
   priceLevel?: number;
 }
 

--- a/client/src/pages/MainPage/index.tsx
+++ b/client/src/pages/MainPage/index.tsx
@@ -38,7 +38,7 @@ interface RestaurantType {
   lng: number;
   address: string;
   rating?: number;
-  photoUrlList?: string[];
+  photoKeyList?: string[];
   openNow?: boolean;
   priceLevel?: number;
 }
@@ -90,6 +90,7 @@ function MainPage() {
         console.log(data.message);
         return;
       }
+      console.log(data.data)
       const { lat, lng, userList, restaurantList, candidateList, userId, userName } = data.data;
 
       const tmp = new Map();

--- a/client/src/pages/MainPage/index.tsx
+++ b/client/src/pages/MainPage/index.tsx
@@ -89,7 +89,6 @@ function MainPage() {
         console.log(data.message);
         return;
       }
-      console.log(data.data)
       const { lat, lng, userList, restaurantList, candidateList, userId, userName } = data.data;
 
       const tmp = new Map();

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -5,7 +5,6 @@ import { RoomModule } from '@room/room.module';
 import * as Joi from 'joi';
 import { SocketModule } from '@socket/socket.module';
 import { MapModule } from '@map/map.module';
-import { RestaurantModule } from '@restaurant/restaurant.module';
 
 @Module({
   imports: [
@@ -32,7 +31,6 @@ import { RestaurantModule } from '@restaurant/restaurant.module';
       }),
       inject: [ConfigService],
     }),
-    RestaurantModule,
     RoomModule,
     SocketModule,
     MapModule,

--- a/server/src/common/response/restaurant.ts
+++ b/server/src/common/response/restaurant.ts
@@ -1,8 +1,8 @@
 import { failRes, successRes } from './index';
 
 export const RESTAURANT_RES = {
-  SUCCESS_SEARCH_RESTAURANT_DETAIL: (rating?: number, openNow?: boolean, priceLevel?: number) =>
-    successRes('음식점의 세부정보를 찾았습니다.', { rating, openNow, priceLevel }),
+  SUCCESS_SEARCH_RESTAURANT_DETAIL: (rating?: number, priceLevel?: number) =>
+    successRes('음식점의 세부정보를 찾았습니다.', { rating, priceLevel }),
 };
 
 export const RESTAURANT_EXCEPTION = {

--- a/server/src/constants/location.ts
+++ b/server/src/constants/location.ts
@@ -11,6 +11,6 @@ export const LOCATION_BOUNDARY = Object.freeze({
 
 export const MAX_RADIUS = 5000;
 
-export const DEFAULT_RADIUS = 5000;
+export const DEFAULT_RADIUS = 2000;
 
 export const MAX_DETAIL_SEARCH_RADIUS = 1000;

--- a/server/src/restaurant/restaurant.controller.ts
+++ b/server/src/restaurant/restaurant.controller.ts
@@ -11,7 +11,7 @@ export class RestaurantController {
   @Get()
   async getRestaurantDetail(@Query() getRestaurantDetailDto: GetRestaurantDetailQueryDto) {
     const { name, address, lat, lng, restaurantId: id } = getRestaurantDetailDto;
-    const { rating, openNow, priceLevel } = await this.restaurantService.getRestaurantDetail(
+    const { rating, priceLevel } = await this.restaurantService.getRestaurantDetail(
       id,
       address,
       name,
@@ -19,6 +19,6 @@ export class RestaurantController {
       lng
     );
 
-    return RESTAURANT_RES.SUCCESS_SEARCH_RESTAURANT_DETAIL(rating, openNow, priceLevel);
+    return RESTAURANT_RES.SUCCESS_SEARCH_RESTAURANT_DETAIL(rating, priceLevel);
   }
 }

--- a/server/src/restaurant/restaurant.controller.ts
+++ b/server/src/restaurant/restaurant.controller.ts
@@ -7,6 +7,7 @@ import { RestaurantService } from './restaurant.service';
 export class RestaurantController {
   constructor(private readonly restaurantService: RestaurantService) {}
 
+  // 당장 이를 사용하지 않기로
   @Get()
   async getRestaurantDetail(@Query() getRestaurantDetailDto: GetRestaurantDetailQueryDto) {
     const { name, address, lat, lng, restaurantId: id } = getRestaurantDetailDto;

--- a/server/src/restaurant/restaurant.d.ts
+++ b/server/src/restaurant/restaurant.d.ts
@@ -22,7 +22,6 @@ export interface PreprocessedRestaurantType {
 export interface MergedRestaurantType extends PreprocessedRestaurantType {
   rating?: number;
   photoKeyList?: string[];
-  openNow?: boolean;
   priceLevel?: number;
 }
 
@@ -38,9 +37,6 @@ export interface RestaurantApiResultType {
 export interface RestaurantDetailType {
   rating?: number;
   photos?: { photo_reference?: string }[];
-  opening_hours?: {
-    open_now?: boolean;
-  };
   price_level?: number;
 }
 

--- a/server/src/restaurant/restaurant.d.ts
+++ b/server/src/restaurant/restaurant.d.ts
@@ -21,7 +21,7 @@ export interface PreprocessedRestaurantType {
 // 기본 음식점 데이터와 상세 정보를 취합한 데이터 타입
 export interface MergedRestaurantType extends PreprocessedRestaurantType {
   rating?: number;
-  photoUrlList?: string[];
+  photoKeyList?: string[];
   openNow?: boolean;
   priceLevel?: number;
 }

--- a/server/src/restaurant/restaurant.d.ts
+++ b/server/src/restaurant/restaurant.d.ts
@@ -18,6 +18,14 @@ export interface PreprocessedRestaurantType {
   address: string;
 }
 
+// 기본 음식점 데이터와 상세 정보를 취합한 데이터 타입
+export interface MergedRestaurantType extends PreprocessedRestaurantType {
+  rating?: number;
+  photoUrlList?: string[];
+  openNow?: boolean;
+  priceLevel?: number;
+}
+
 export interface RestaurantApiResultType {
   meta: {
     is_end: boolean;
@@ -29,7 +37,7 @@ export interface RestaurantApiResultType {
 
 export interface RestaurantDetailType {
   rating?: number;
-  photos?: { photo_reference: string }[];
+  photos?: { photo_reference?: string }[];
   opening_hours?: {
     open_now?: boolean;
   };
@@ -37,6 +45,6 @@ export interface RestaurantDetailType {
 }
 
 export interface RestaurantDetailResponseType {
-  candidates: RestaurantDetail[];
+  candidates: RestaurantDetailType[];
   status: string;
 }

--- a/server/src/restaurant/restaurant.service.ts
+++ b/server/src/restaurant/restaurant.service.ts
@@ -158,12 +158,10 @@ export class RestaurantService {
         rating,
         photos, // 이 후 이미지 API 를 위해 일단 놔둠
         price_level: priceLevel,
-        opening_hours: openingHours,
       } = result;
-      const openNow = openingHours?.open_now;
       const photoKeyList = photos.map((photo) => photo?.photo_reference);
 
-      return { id, rating, openNow, priceLevel, photoKeyList };
+      return { id, rating, priceLevel, photoKeyList };
     } catch (error) {
       // 단일 요청에 대한 에러 처리가 아닌, 모든 음식점에 대해 일괄적으로 상세정보를 불러오고
       // 만약 상세정보가 없을 시에도 에러를 반환하는 것이 아닌 값을 반환해주어야 함

--- a/server/src/restaurant/restaurant.service.ts
+++ b/server/src/restaurant/restaurant.service.ts
@@ -161,9 +161,9 @@ export class RestaurantService {
         opening_hours: openingHours,
       } = result;
       const openNow = openingHours?.open_now;
-      const photoUrlList = photos.map((photo) => photo?.photo_reference);
+      const photoKeyList = photos.map((photo) => photo?.photo_reference);
 
-      return { id, rating, openNow, priceLevel, photoUrlList };
+      return { id, rating, openNow, priceLevel, photoKeyList };
     } catch (error) {
       // 단일 요청에 대한 에러 처리가 아닌, 모든 음식점에 대해 일괄적으로 상세정보를 불러오고
       // 만약 상세정보가 없을 시에도 에러를 반환하는 것이 아닌 값을 반환해주어야 함

--- a/server/src/restaurant/restaurant.service.ts
+++ b/server/src/restaurant/restaurant.service.ts
@@ -12,7 +12,6 @@ import {
 import { RESTAURANT_CATEGORY, RESTAURANT_DETAIL_FIELD } from '@constants/restaurant';
 import { MAX_RADIUS, MAX_DETAIL_SEARCH_RADIUS } from '@constants/location';
 import { LOCATION_EXCEPTION } from '@response/location';
-import { RESTAURANT_EXCEPTION } from '@common/response/restaurant';
 import { RESTAURANT_DETAIL_API_URL, RESTAURANT_LIST_API_URL } from '@constants/api';
 
 const restaurantListApiConfig = (
@@ -127,7 +126,7 @@ export class RestaurantService {
       throw new CustomException(LOCATION_EXCEPTION.OUT_OF_MAX_RADIUS);
     }
 
-    const restaurantSet = new Set();
+    const restaurantMap: { [index: string]: PreprocessedRestaurantType } = {};
 
     const restaurantApiResult = await Promise.all(
       RESTAURANT_CATEGORY.map((category) =>
@@ -136,23 +135,16 @@ export class RestaurantService {
     );
     restaurantApiResult.forEach((restaurantList) => {
       this.restaurantPreprocessing(restaurantList).forEach((restaurant) => {
-        restaurantSet.add(restaurant);
+        restaurantMap[restaurant.id] = restaurant;
       });
     });
 
-    return Array.from(restaurantSet) as PreprocessedRestaurantType[];
+    return restaurantMap;
   }
 
-  async getRestaurantDetail(
-    restaurantId: string,
-    address: string,
-    name: string,
-    lat: number,
-    lng: number
-  ) {
+  async getRestaurantDetail(id: string, address: string, name: string, lat: number, lng: number) {
     try {
       const {
-        request,
         data: { candidates },
       } = await axios.get<RestaurantDetailResponseType>(
         RESTAURANT_DETAIL_API_URL,
@@ -165,13 +157,18 @@ export class RestaurantService {
       const {
         rating,
         photos, // 이 후 이미지 API 를 위해 일단 놔둠
-        opening_hours: { open_now: openNow },
         price_level: priceLevel,
+        opening_hours: openingHours,
       } = result;
+      const openNow = openingHours?.open_now;
+      const photoUrlList = photos.map((photo) => photo?.photo_reference);
 
-      return { rating, openNow, priceLevel };
+      return { id, rating, openNow, priceLevel, photoUrlList };
     } catch (error) {
-      throw new CustomException(RESTAURANT_EXCEPTION.FAIL_SEARCH_RESTAURANT_DETAIL);
+      // 단일 요청에 대한 에러 처리가 아닌, 모든 음식점에 대해 일괄적으로 상세정보를 불러오고
+      // 만약 상세정보가 없을 시에도 에러를 반환하는 것이 아닌 값을 반환해주어야 함
+      // 상세정보가 없는 것은 서비스 적으로 전혀 문제되는 상황이 아님.
+      return { id };
     }
   }
 }

--- a/server/src/room/room.schema.ts
+++ b/server/src/room/room.schema.ts
@@ -1,6 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
-import { PreprocessedRestaurantType as RestaurantType } from '@restaurant/restaurant';
+import { MergedRestaurantType as RestaurantType } from '@restaurant/restaurant';
 
 export type RoomDocument = Room & Document;
 export type RoomDynamicDocument = RoomDynamic & Document;

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -28,13 +28,8 @@ export class RoomService {
       const restaurantDetailList = await Promise.all(
         Object.keys(restaurantMap).map((restaurantId) => {
           const restaurant = restaurantMap[restaurantId];
-          return this.restaurantService.getRestaurantDetail(
-            restaurantId,
-            restaurant.address,
-            restaurant.name,
-            restaurant.lat,
-            restaurant.lng
-          );
+          const { name, address, lat, lng } = restaurant;
+          return this.restaurantService.getRestaurantDetail(restaurantId, address, name, lat, lng);
         })
       );
       const mergedRestaurantDataList = restaurantDetailList.map((restaurantDetailData) => {


### PR DESCRIPTION
## 링크(관련 이슈)
#109 

<br>

## 개요
음식점 생성 시 DB 상에 음식점 상세정보가 함께 포함된 음식점 정보를 적재하도록 수정했습니다.

<br>

## 내용
모임 생성 요청 시 (POST /api/room) 기존에는 기본 음식점 정보만 DB에 적재했지만, 수정된 코드에서는 상세정보도 전부 가져와 적재합니다.
이 때 추가된 필드는 다음과 같습니다.
```
{
  rating?: number; // 음식점의 평점
  photoKeyList?: string[]; // 음식점 관련 사진을 가져오기 위한 키 값의 리스트
  priceLevel?: number; // 해당 음식점의 가격대 정보
}
```


<br>

## 비고
- 기본 음식점 탐색 반경을 5km에서 2km로 수정했습니다.

<br>

## 리뷰어한테 할 말
300~400 개 규모 음식점일 때 모임 생성 요청 시 약 2초정도 소요되는 것을 확인했습니다.