### PR TITLE
toast 공통 컴포넌트 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,13 @@
+import Toast from '@components/Toast';
 import Router from './Router';
 
 function App() {
-  return <Router />;
+  return (
+    <>
+      <Toast />
+      <Router />
+    </>
+  );
 }
 
 export default App;

--- a/client/src/components/LinkShareButton/index.tsx
+++ b/client/src/components/LinkShareButton/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ReactComponent as ShareImage } from '@assets/images/share.svg';
+import { TOAST_DURATION_TIME, SUCCCESS_COPY_MESSAGE, FAIL_COPY_MESSAGE } from '@constants/toast';
 import { useToast } from '@hooks/useToast';
 import { ButtonBox } from './styles';
 
@@ -10,9 +11,9 @@ function LinkShareButton() {
   const copyClipboard = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      fireToast({ content: '✅ 클립보드에 복사되었습니다.', duration: 2500, bottom: 80 });
+      fireToast({ content: SUCCCESS_COPY_MESSAGE, duration: TOAST_DURATION_TIME, bottom: 80 });
     } catch (error) {
-      fireToast({ content: '❌ 클립보드 복사에 실패했습니다.', duration: 2500, bottom: 80 });
+      fireToast({ content: FAIL_COPY_MESSAGE, duration: TOAST_DURATION_TIME, bottom: 80 });
     }
   };
 

--- a/client/src/components/LinkShareButton/index.tsx
+++ b/client/src/components/LinkShareButton/index.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { ReactComponent as ShareImage } from '@assets/images/share.svg';
+import { useToast } from '@hooks/useToast';
 import { ButtonBox } from './styles';
 
-// TODO: alert는 추후 토스트 형태로 일괄 변경 예정
 function LinkShareButton() {
+  const { fireToast } = useToast();
   const location = window.location.href; // 현재 URL
 
   const copyClipboard = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      alert('클립보드 복사 성공');
+      fireToast({ content: '✅ 클립보드에 복사되었습니다.', duration: 2500, bottom: 80 });
     } catch (error) {
-      alert('클립보드 복사 실패');
+      fireToast({ content: '❌ 클립보드 복사에 실패했습니다.', duration: 2500, bottom: 80 });
     }
   };
 

--- a/client/src/components/MeetLocationSettingFooter/index.tsx
+++ b/client/src/components/MeetLocationSettingFooter/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { ReactComponent as SearchImage } from '@assets/images/search.svg';
 import { NAVER_ADDRESS } from '@constants/map';
 import { useMeetLocationStore } from '@store/index';
+import { useToast } from '@hooks/useToast';
 
 import { FooterBox, SearchBarBox, StartButton } from './styles';
 
@@ -19,6 +20,7 @@ function MeetLocationSettingFooter() {
   const { meetLocation, updateMeetLocation } = useMeetLocationStore((state) => state);
   const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
+  const { fireToast } = useToast();
 
   // 좌표 -> 주소 변환 & setAddress
   const updateAddress = (lat: number, lng: number) => {
@@ -32,7 +34,8 @@ function MeetLocationSettingFooter() {
       // eslint-disable-next-line consistent-return
       (status, response) => {
         if (status !== naver.maps.Service.Status.OK) {
-          alert('주소 변환 실패');
+          fireToast({ content: '주소 변환에 실패했습니다.', duration: 2500, bottom: 280 });
+          return;
         }
 
         setAddress(response.v2.address.roadAddress || response.v2.address.jibunAddress);
@@ -59,15 +62,16 @@ function MeetLocationSettingFooter() {
       // eslint-disable-next-line func-names, consistent-return
       function (status, response) {
         if (status !== naver.maps.Service.Status.OK) {
-          return alert('검색 실패');
+          fireToast({ content: '검색에 실패했습니다.', duration: 2500, bottom: 280 });
+          return;
         }
 
         const result = response.v2; // 검색 결과의 컨테이너
         const items = result.addresses; // 검색 결과의 배열
 
         if (items.length === 0) {
-          // TODO: 추후 토스트 알림으로 변경
-          return alert('검색결과가 없습니다.');
+          fireToast({ content: '검색결과가 없습니다.', duration: 2500, bottom: 280 });
+          return;
         }
 
         // 첫번째 검색 결과로 처리

--- a/client/src/components/MeetLocationSettingFooter/index.tsx
+++ b/client/src/components/MeetLocationSettingFooter/index.tsx
@@ -3,6 +3,12 @@ import React, { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ReactComponent as SearchImage } from '@assets/images/search.svg';
 import { NAVER_ADDRESS } from '@constants/map';
+import {
+  TOAST_DURATION_TIME,
+  FAIL_UPDATE_ADDR_MESSAGE,
+  NO_RESULTS_MESSAGE,
+  FAIL_SEARCH_MESSAGE,
+} from '@constants/toast';
 import { useMeetLocationStore } from '@store/index';
 import { useToast } from '@hooks/useToast';
 
@@ -34,7 +40,11 @@ function MeetLocationSettingFooter() {
       // eslint-disable-next-line consistent-return
       (status, response) => {
         if (status !== naver.maps.Service.Status.OK) {
-          fireToast({ content: '주소 변환에 실패했습니다.', duration: 2500, bottom: 280 });
+          fireToast({
+            content: FAIL_UPDATE_ADDR_MESSAGE,
+            duration: TOAST_DURATION_TIME,
+            bottom: 280,
+          });
           return;
         }
 
@@ -62,7 +72,11 @@ function MeetLocationSettingFooter() {
       // eslint-disable-next-line func-names, consistent-return
       function (status, response) {
         if (status !== naver.maps.Service.Status.OK) {
-          fireToast({ content: '검색에 실패했습니다.', duration: 2500, bottom: 280 });
+          fireToast({
+            content: FAIL_SEARCH_MESSAGE,
+            duration: TOAST_DURATION_TIME,
+            bottom: 280,
+          });
           return;
         }
 
@@ -70,7 +84,7 @@ function MeetLocationSettingFooter() {
         const items = result.addresses; // 검색 결과의 배열
 
         if (items.length === 0) {
-          fireToast({ content: '검색결과가 없습니다.', duration: 2500, bottom: 280 });
+          fireToast({ content: NO_RESULTS_MESSAGE, duration: TOAST_DURATION_TIME, bottom: 280 });
           return;
         }
 

--- a/client/src/components/Toast/index.tsx
+++ b/client/src/components/Toast/index.tsx
@@ -1,0 +1,14 @@
+import { useToastStore } from '@store/index';
+import { ToastLayout, ToastContentSpan } from './styles';
+
+function Toast() {
+  const { isOpen, content, bottom } = useToastStore();
+
+  return (
+    <ToastLayout bottom={bottom} visible={isOpen}>
+      <ToastContentSpan>{content}</ToastContentSpan>
+    </ToastLayout>
+  );
+}
+
+export default Toast;

--- a/client/src/components/Toast/styles.tsx
+++ b/client/src/components/Toast/styles.tsx
@@ -1,0 +1,50 @@
+import styled, { keyframes } from 'styled-components';
+
+// animations
+const fadeIn = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+`;
+
+const fadeOut = keyframes`
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+`;
+
+interface ToastStylePropsType {
+  visible: boolean;
+  bottom: number;
+}
+
+export const ToastLayout = styled.div<ToastStylePropsType>`
+  position: absolute;
+  width: 14rem;
+  bottom: ${({ bottom }) => bottom}px;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.75);
+  border-radius: 30px;
+  padding: 15px 20px;
+  text-align: center;
+
+  /* 중앙정렬 */
+  left: 50%;
+  margin-left: -7rem;
+
+  /* show/hide */
+  visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
+  animation: ${({ visible }) => (visible ? fadeIn : fadeOut)} 0.15s ease-out;
+  transition: visibility 0.15s ease-out;
+`;
+
+export const ToastContentSpan = styled.span`
+  color: #fff;
+  font-size: 0.8rem;
+`;

--- a/client/src/constants/toast.ts
+++ b/client/src/constants/toast.ts
@@ -1,0 +1,6 @@
+export const TOAST_DURATION_TIME = 2500;
+export const SUCCCESS_COPY_MESSAGE = '✅ 클립보드에 복사되었습니다.';
+export const FAIL_COPY_MESSAGE = '❌ 클립보드 복사에 실패했습니다.';
+export const NO_RESULTS_MESSAGE = '검색결과가 없습니다.';
+export const FAIL_SEARCH_MESSAGE = '검색에 실패했습니다.';
+export const FAIL_UPDATE_ADDR_MESSAGE = '주소 변환에 실패했습니다.';

--- a/client/src/hooks/useToast.tsx
+++ b/client/src/hooks/useToast.tsx
@@ -1,0 +1,24 @@
+import { useToastStore } from '@store/index';
+
+interface ToastType {
+  content: string;
+  bottom?: number;
+  duration?: number;
+}
+
+export function useToast() {
+  const { updateIsOpen, updateToast } = useToastStore((state) => state);
+
+  const fireToast = (toast: ToastType) => {
+    const { content, bottom, duration } = toast;
+
+    updateIsOpen(true);
+    updateToast(content, bottom, duration);
+
+    setTimeout(() => {
+      updateIsOpen(false);
+    }, toast.duration);
+  };
+
+  return { fireToast };
+}

--- a/client/src/store/index.tsx
+++ b/client/src/store/index.tsx
@@ -10,3 +10,21 @@ export const useMeetLocationStore = create<MeetLocationStoreType>((set) => ({
   meetLocation: { lat: NAVER_LAT, lng: NAVER_LNG },
   updateMeetLocation: (lat, lng) => set(() => ({ meetLocation: { lat, lng } })),
 }));
+
+interface ToastStoreType {
+  isOpen: boolean;
+  content: string;
+  bottom: number; // 아래에서 몇 px 띄울건지 지정
+  duration: number;
+  updateIsOpen: (isOpen: boolean) => void;
+  updateToast: (content: string, bottom?: number, duration?: number) => void;
+}
+
+export const useToastStore = create<ToastStoreType>((set) => ({
+  isOpen: false,
+  content: '',
+  bottom: 100,
+  duration: 2000,
+  updateIsOpen: (isOpen) => set(() => ({ isOpen })),
+  updateToast: (content, bottom, duration) => set(() => ({ content, bottom, duration })),
+}));


### PR DESCRIPTION
## 링크(관련 이슈)
#103 
<br>

## 개요
여러 화면에 공통적으로 쓰일 토스트 컴포넌트를 구현하였습니다. 
커스텀 훅으로 사용이 가능합니다. 

```
// 사용 예시

// 상단에서 custom hook import
import { useToast } from '@hooks/useToast';

// 컴포넌트 내부
const { fireToast } = useToast();

// duration: 토스트 지속 시간, bottom: 아래에서 몇 px 띄울건지 지정
fireToast({ content: '주소 변환에 실패했습니다.', duration: 2500, bottom: 280 });
```

<br>

## 내용
- toast 공통 컴포넌트 구현
- 기존 alert 모달로 뜨고 있는 것을 toast로 변경

<br>

## 비고
### 개발노트
- [커스텀 토스트 컴포넌트 만들기](https://delicious-guys.notion.site/4b79b1d5233c410a85e90f0013ce8eee)
### 화면
<img width="240" alt="스크린샷 2022-12-05 오후 7 13 06" src="https://user-images.githubusercontent.com/55318618/205611437-e3bec78c-2b4d-4b92-8676-09e373b4a3c4.png">

<img width="240" alt="스크린샷 2022-12-05 오후 7 12 24" src="https://user-images.githubusercontent.com/55318618/205611291-fb0725e0-0ad0-425d-b14e-ad0c59a69405.png">

<br>

## 리뷰어한테 할 말