### PR TITLE
상세 카테고리가 없을 경우에 대한 예외 처리

### DIFF
--- a/server/src/restaurant/restaurant.service.ts
+++ b/server/src/restaurant/restaurant.service.ts
@@ -103,10 +103,13 @@ export class RestaurantService {
         x: lng,
         road_address_name: address,
       } = restaurant;
+
+      const categorySplitArr = category.split('>');
+
       const preprocessedRestaurant: PreprocessedRestaurantType = {
         id: id,
         name: name,
-        category: category.split('>')[1].trim() || '',
+        category: categorySplitArr.length > 1 ? categorySplitArr[1].trim() : '',
         phone: phone || '',
         lat: Number.parseFloat(lat),
         lng: Number.parseFloat(lng),


### PR DESCRIPTION
## 링크(관련 이슈)
#124

<br>

## 개요
식당에 상세 카테고리가 없을 경우, 식당 데이터 처리하는 로직에서 에러가 발생하여 로직을 긴급 수정하였습니다.

<br>

## 내용
- 상세 카테고리가 없을 경우, 카테고리를 빈 문자열로 지정

<br>

## 비고
<img width="1057" alt="스크린샷 2022-12-08 오전 1 04 05" src="https://user-images.githubusercontent.com/55318618/206231921-60055a15-1797-4dc2-a63a-a9855de0e34f.png">

<br>

## 리뷰어한테 할 말
