### PR TITLE
투표 결과를 받아오는 socket.on 내부 코드가 의미없이 실행되던 버그 수정 

### DIFF
--- a/client/src/components/RestaurantVoteButton/index.tsx
+++ b/client/src/components/RestaurantVoteButton/index.tsx
@@ -129,7 +129,7 @@ function RestaurantVoteButton({
         <VoteButton type="button" isVoted={isVoted} onClick={handleClick}>
           {isVoted ? (
             <>
-              <XImage width="15" fill="white" /> <span>&nbsp; 투표</span>
+              <XImage width="10" fill="white" /> <span>&nbsp; 투표</span>
             </>
           ) : (
             <>

--- a/client/src/components/RestaurantVoteButton/index.tsx
+++ b/client/src/components/RestaurantVoteButton/index.tsx
@@ -67,6 +67,10 @@ function RestaurantVoteButton({
     // 사용자가 이미 투표한 식당인 경우, 투표 취소
     if (isVoted) {
       socket.on('cancelVoteRestaurantResult', (result: VoteResultType) => {
+        if (restaurantId !== result.data?.restaurantId) {
+          return;
+        }
+
         if (result.message === FAIL_CANCEL_VOTE) {
           fireToast({
             content: FAIL_CANCEL_VOTE_MESSAGE,
@@ -84,6 +88,10 @@ function RestaurantVoteButton({
 
     // 사용자가 투표하지 않은 식당인 경우, 투표
     socket.on('voteRestaurantResult', (result: VoteResultType) => {
+      if (restaurantId !== result.data?.restaurantId) {
+        return;
+      }
+
       if (result.message === FAIL_VOTE) {
         fireToast({
           content: FAIL_VOTE_MESSAGE,

--- a/client/src/components/RestaurantVoteButton/index.tsx
+++ b/client/src/components/RestaurantVoteButton/index.tsx
@@ -48,45 +48,36 @@ function RestaurantVoteButton({
       return;
     }
 
-    socket.on('userVoteRestaurantIdList', (result: VoteRestaurantListType) => {
-      votedRestaurantListRef.current = result.data.voteRestaurantIdList;
-      setIsVoted(votedRestaurantListRef.current.includes(restaurantId));
-    });
     socket.emit('getUserVoteRestaurantIdList');
   };
 
   useEffect(() => {
-    setVotedRestaurantList();
-  }, []);
-
-  const voteRestaurant = () => {
     if (!(socket instanceof Socket)) {
       return;
     }
 
-    // 사용자가 이미 투표한 식당인 경우, 투표 취소
-    if (isVoted) {
-      socket.on('cancelVoteRestaurantResult', (result: VoteResultType) => {
-        if (restaurantId !== result.data?.restaurantId) {
-          return;
-        }
+    socket.on('userVoteRestaurantIdList', (result: VoteRestaurantListType) => {
+      votedRestaurantListRef.current = result.data.voteRestaurantIdList;
+      setIsVoted(votedRestaurantListRef.current.includes(restaurantId));
+    });
 
-        if (result.message === FAIL_CANCEL_VOTE) {
-          fireToast({
-            content: FAIL_CANCEL_VOTE_MESSAGE,
-            duration: TOAST_DURATION_TIME,
-            bottom: 280,
-          });
-          setIsVoted(true);
-          return;
-        }
-        setIsVoted(false);
-      });
-      socket.emit('cancelVoteRestaurant', { restaurantId });
-      return;
-    }
+    socket.on('cancelVoteRestaurantResult', (result: VoteResultType) => {
+      if (restaurantId !== result.data?.restaurantId) {
+        return;
+      }
 
-    // 사용자가 투표하지 않은 식당인 경우, 투표
+      if (result.message === FAIL_CANCEL_VOTE) {
+        fireToast({
+          content: FAIL_CANCEL_VOTE_MESSAGE,
+          duration: TOAST_DURATION_TIME,
+          bottom: 280,
+        });
+        setIsVoted(true);
+        return;
+      }
+      setIsVoted(false);
+    });
+
     socket.on('voteRestaurantResult', (result: VoteResultType) => {
       if (restaurantId !== result.data?.restaurantId) {
         return;
@@ -103,6 +94,22 @@ function RestaurantVoteButton({
       }
       setIsVoted(true);
     });
+
+    setVotedRestaurantList();
+  }, []);
+
+  const voteRestaurant = () => {
+    if (!(socket instanceof Socket)) {
+      return;
+    }
+
+    // 사용자가 이미 투표한 식당인 경우, 투표 취소
+    if (isVoted) {
+      socket.emit('cancelVoteRestaurant', { restaurantId });
+      return;
+    }
+
+    // 사용자가 투표하지 않은 식당인 경우, 투표
     socket.emit('voteRestaurant', { restaurantId });
   };
 


### PR DESCRIPTION
## 링크(관련 이슈)
#80 

<br>

## 개요
1. 투표 버튼에서 `voteRestaurant` 함수 안에 
서버로부터 온 투표, 투표 취소 결과를 listening 하는 로직을 넣었는데요, (`socket.on (...)`)
현재 로직에서는 한 버튼이 투표/투표 취소가 눌렸을 때 다른 버튼들도 이 코드가 실행되어서 
isVoted가 변경되는 버그를 발견해서, 급히 수정하였습니다.
2. 투표 취소 버튼(`x` 아이콘) 크기를 축소하였습니다.

<br>

## 내용
- 투표 버튼 컴포넌트 내부의 투표/투표 취소 로직에서 
  현재 투표/투표 취소가 발생한 id랑 버튼의 restautantId를 비교해서 
같을 때만 투표, 투표 취소 로직이 실행되게 함
- `x` 아이콘 크기 축소: 15 -> 10

<br>

## 비고
<img width="359" alt="스크린샷 2022-12-10 오후 8 01 23" src="https://user-images.githubusercontent.com/55318618/206851769-90303b33-b9fd-4946-8df3-86db3af6c21d.png">

<br>

## 리뷰어한테 할 말
`x` 아이콘 크기는 저 정도면 되겠죠?