### PR TITLE
후보 식당 클릭시 상세 페이지 이동

### DIFF
--- a/client/src/components/RestaurantCandidateList/index.tsx
+++ b/client/src/components/RestaurantCandidateList/index.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react';
 
 import RestaurantRow from '@components/RestaurantRow';
-import { RESTAURANT_LIST_TYPES } from '@constants/modal';
+import { RESTAURANT_DETAIL_TYPES, RESTAURANT_LIST_TYPES } from '@constants/modal';
 
 import { useSocketStore } from '@store/socket';
 import { Socket } from 'socket.io-client';
 import EmptyListPlaceholder from '@components/EmptyListPlaceholder';
-import { CandidateListModalBox, CandidateListModalLayout } from './styles';
+import { useRestaurantDetailLayerStatusStore, useSelectedRestaurantDataStore } from '@store/index';
+import { CandidateItem, CandidateListModalBox, CandidateListModalLayout } from './styles';
 
 interface CandidateType extends RestaurantType {
   count?: number;
@@ -29,6 +30,10 @@ interface VoteResultType {
 export function CandidateListModal({ restaurantData }: PropsType) {
   const { socket } = useSocketStore((state) => state);
   const [candidateData, setCandidateData] = useState<CandidateType[]>([]); // 투표된 음식점의 정보 데이터
+  const { updateRestaurantDetailLayerStatus } = useRestaurantDetailLayerStatusStore(
+    (state) => state
+  );
+  const { updateSelectedRestaurantData } = useSelectedRestaurantDataStore((state) => state);
 
   const compare = (a: CandidateType, b: CandidateType): number => {
     const aCount = a.count || 0;
@@ -89,14 +94,24 @@ export function CandidateListModal({ restaurantData }: PropsType) {
         <EmptyListPlaceholder />
       ) : (
         <CandidateListModalBox>
-          {[...candidateData].sort(compare).map((candidate: CandidateType) => (
-            <RestaurantRow
-              key={candidate.id}
-              restaurant={candidate}
-              restaurantListType={RESTAURANT_LIST_TYPES.candidate}
-              likeCnt={candidate.count}
-            />
-          ))}
+          {[...candidateData].sort(compare).map((candidate: CandidateType) => {
+            return (
+              <CandidateItem
+                onClick={() => {
+                  updateRestaurantDetailLayerStatus(RESTAURANT_DETAIL_TYPES.show);
+                  updateSelectedRestaurantData(candidate);
+                }}
+                key={candidate.id}
+              >
+                <RestaurantRow
+                  key={candidate.id}
+                  restaurant={candidate}
+                  restaurantListType={RESTAURANT_LIST_TYPES.candidate}
+                  likeCnt={candidate.count}
+                />
+              </CandidateItem>
+            );
+          })}
         </CandidateListModalBox>
       )}
     </CandidateListModalLayout>

--- a/client/src/components/RestaurantCandidateList/styles.tsx
+++ b/client/src/components/RestaurantCandidateList/styles.tsx
@@ -9,8 +9,12 @@ export const CandidateListModalLayout = styled.div`
 
 export const CandidateListModalBox = styled.div`
   width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
+`;
+
+export const CandidateItem = styled.li`
+  list-style: none;
+  padding-bottom: 5%;
+  &:last-child {
+    padding-bottom: 0;
+  }
 `;


### PR DESCRIPTION
## 링크(관련 이슈)
#74 
<br>

## 개요
후보 식당 클릭시 상세 페이지 이동

<br>

## 내용
- 후보 식당 리스트에서 특정 식당 선택시 식당의 상세 페이지로 이동하도록 컴포넌트 재사용

<br>

## 비고
<details>
<summary>동작 gif</summary>
<div markdown="1">
&nbsp;&nbsp;<img src="https://user-images.githubusercontent.com/74449232/206870376-7d929c60-549b-43df-851c-631f96fdae65.gif" width=300 />
</video>
<br>
</div>
</details>


<br>

## 리뷰어한테 할 말
- `스타일 중복 관련`  
  식당 리스트 style 파일의 내용을 후보 식당 리스트 style 파일에 똑같이 옮겨 놓았는데 지금 이런 상황과 유사한 케이스(공통 스타일)들이 몇군데 더 있습니다. 이에 대해서 따로 이슈 생성해서 스타일 파일을 관리하는 식으로 리팩토링 진행하면 좋을 것 같습니다.