### PR TITLE
모임 생성 페이지 내 세부 주소를 2줄까지만 허용하고 그 이후에는 말줄임 표시가 나오도록 수정

### DIFF
--- a/client/src/components/MeetLocationSettingFooter/index.tsx
+++ b/client/src/components/MeetLocationSettingFooter/index.tsx
@@ -13,7 +13,7 @@ import { useToast } from '@hooks/useToast';
 
 import { apiService } from '@apis/index';
 import { URL_PATH } from '@constants/url';
-import { FooterBox, GuideTextBox, SearchBarBox, StartButton } from './styles';
+import { AddressBox, FooterBox, GuideTextBox, SearchBarBox, StartButton } from './styles';
 
 function MeetLocationSettingFooter() {
   const [address, setAddress] = useState<string>(NAVER_ADDRESS);
@@ -121,7 +121,7 @@ function MeetLocationSettingFooter() {
         </button>
       </SearchBarBox>
 
-      <div>{address}</div>
+      <AddressBox>{address}</AddressBox>
 
       <StartButton
         title="시작하기"

--- a/client/src/components/MeetLocationSettingFooter/styles.tsx
+++ b/client/src/components/MeetLocationSettingFooter/styles.tsx
@@ -58,3 +58,13 @@ export const StartButton = styled.button`
   border: none;
   border-radius: 4px;
 `;
+
+export const AddressBox = styled.div`
+  width: 55%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: center;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+`

--- a/client/src/components/MeetLocationSettingFooter/styles.tsx
+++ b/client/src/components/MeetLocationSettingFooter/styles.tsx
@@ -61,6 +61,7 @@ export const StartButton = styled.button`
 
 export const AddressBox = styled.div`
   width: 55%;
+  height: 2rem;
   overflow: hidden;
   text-overflow: ellipsis;
   text-align: center;


### PR DESCRIPTION
## 링크(관련 이슈)
#173 
<br>

## 개요
모임 생성 페이지의 푸터 내 세부 주소가 두줄까지 표시되도록 설정 했고, 그 이후에는 말줄임 표시(ellipsis)가 되도록 했습니다.

<br>

## 내용
<img width="200" alt="image" src="https://user-images.githubusercontent.com/89074053/206992373-13e49d4e-cf06-4a42-9f3c-579b813be7d9.png">

<br>

## 비고
{ 기타 내용, 의존성있는 작업, 스크린샷 }

<br>

## 리뷰어한테 할 말
{ 집중적으로 리뷰해줬으면 하는 부분 }