### PR TITLE
식당 이름 말줄임표 처리

### DIFF
--- a/client/src/components/RestaurantRow/styles.tsx
+++ b/client/src/components/RestaurantRow/styles.tsx
@@ -46,10 +46,14 @@ export const InfoBox = styled.div`
 `;
 
 export const NameBox = styled.div`
-  width: 100%;
+  width: 80%;
   font-weight: 700;
   height: 15%;
   font-size: 1rem;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  word-break: break-all;
 `;
 
 export const CategoryBox = styled.div`


### PR DESCRIPTION
## 링크(관련 이슈)
#176 
<br>

## 개요
식당 이름이 길 때 잘리지 않게 하기 위해 CSS ellipsis 처리 추가

<br>

## 내용
- 다음 CSS 속성들을 적용했습니다.
`overflow: hidden;`: 박스에서 넘쳐난 텍스트 숨기기
`white-space: nowrap;`: 줄바꿈 X
`text-overflow: ellipsis;`: ... 말줄임표 처리
`word-break: break-all;`: 어절이 끊어져서 줄바꿈됨

<br>

## 비고
<img width="250" alt="스크린샷 2022-12-12 오후 8 32 59" src="https://user-images.githubusercontent.com/55318618/207035035-06d79e2c-e195-45e4-ad72-aeff97599c71.png">


<br>

## 리뷰어한테 할 말