### PR TITLE
style: 지도 로딩 시 배경에 파란 화면이 나오던 현상 수정

### DIFF
--- a/client/src/pages/MainPage/styles.tsx
+++ b/client/src/pages/MainPage/styles.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import * as palette from '@styles/Variables';
 
 export const MainPageLayout = styled.div`
-  background-color: blue;
   width: 100%;
   height: 100%;
   display: flex;
@@ -16,7 +15,6 @@ export const MapBox = styled.div`
   height: 100%;
   z-index: 1;
   position: absolute;
-  background-color: white;
   &:focus-visible {
     outline: none;
   }


### PR DESCRIPTION
## 링크(관련 이슈)
#188 
<br>

## 개요
지도 로딩 시 나오던 배경의 파란 화면을 나오지 않도록 수정했습니다.

<br>

## 내용
{ 변경사항(작업내용) }

<br>

## 비고
{ 기타 내용, 의존성있는 작업, 스크린샷 }

<br>

## 리뷰어한테 할 말
{ 집중적으로 리뷰해줬으면 하는 부분 }