### PR TITLE
길찾기 지도의 zoom 레벨 경로에 알맞게 변경

### DIFF
--- a/client/src/components/RestaurantDetail/RestaurantDetailDrivingInfo/index.tsx
+++ b/client/src/components/RestaurantDetail/RestaurantDetailDrivingInfo/index.tsx
@@ -6,6 +6,8 @@ import { distanceToDisplay } from '@utils/distance';
 import { msToTimeDisplay } from '@utils/time';
 import { ERROR_REASON } from '@constants/error';
 import { apiService } from '@apis/index';
+import { useToast } from '@hooks/useToast';
+import { TOAST_DURATION_TIME } from '@constants/toast';
 import { DrivingInfoBox, MapBox } from './styles';
 
 interface PropsType {
@@ -15,6 +17,7 @@ interface PropsType {
 function RestaurantDetailDrivingInfo({ restaurantPos }: PropsType) {
   const navigate = useNavigate();
   const { userLocation } = useUserLocationStore();
+  const { fireToast } = useToast();
   const [drivingInfo, setDrivingInfo] = useState<DrivingInfoType>();
 
   const mapRef = useRef<HTMLDivElement>(null);
@@ -41,7 +44,6 @@ function RestaurantDetailDrivingInfo({ restaurantPos }: PropsType) {
       if (error.response.status === 500) {
         throw new Error(ERROR_REASON.INTERNAL_SERVER_ERROR);
       }
-      console.log(error.response.data.message ?? '길찾기 정보를 불러오는데 실패했습니다.');
       return {} as DrivingInfoType;
     }
   };
@@ -73,6 +75,11 @@ function RestaurantDetailDrivingInfo({ restaurantPos }: PropsType) {
     const { path } = await getDrivingInfo(userPos, restaurantPos);
 
     if (!path) {
+      fireToast({
+        content: '길찾기 정보 요청에 실패했습니다.',
+        duration: TOAST_DURATION_TIME,
+        bottom: 80,
+      });
       return;
     }
 

--- a/client/src/components/RestaurantDetail/RestaurantDetailDrivingInfo/index.tsx
+++ b/client/src/components/RestaurantDetail/RestaurantDetailDrivingInfo/index.tsx
@@ -96,8 +96,8 @@ function RestaurantDetailDrivingInfo({ restaurantPos }: PropsType) {
       strokeWeight: 5, // 선 두께
     });
 
-    // 지도 중심을 경로의 중심으로 설정
-    map.setCenter(polyline.getBounds().getCenter());
+    // 지도의 범위를 경로의 범위로 설정
+    map.fitBounds(polyline.getBounds());
   }, []);
 
   useEffect(() => {

--- a/server/src/map/map.d.ts
+++ b/server/src/map/map.d.ts
@@ -5,7 +5,6 @@ interface StartOrGoalType {
 export interface SummaryType {
   start: StartOrGoalType; // 출발지
   goal: StartOrGoalType; // 도착지
-  bbox: number[][]; // 전체 경로 경계 영역(eft bottom point, right top point)
   distance: number; // 총 거리
   duration: number; // 소요 시간(millisecond)
   tollFare: number; // 통행 요금(톨게이트)
@@ -30,7 +29,6 @@ export interface NaverDrivingResType {
 export interface DrivingInfoType {
   start: number[];
   goal: number[];
-  bbox: number[][];
   distance: number;
   duration: number;
   tollFare: number;

--- a/server/src/map/map.d.ts
+++ b/server/src/map/map.d.ts
@@ -5,6 +5,7 @@ interface StartOrGoalType {
 export interface SummaryType {
   start: StartOrGoalType; // 출발지
   goal: StartOrGoalType; // 도착지
+  bbox: number[][]; // 전체 경로 경계 영역(eft bottom point, right top point)
   distance: number; // 총 거리
   duration: number; // 소요 시간(millisecond)
   tollFare: number; // 통행 요금(톨게이트)
@@ -24,4 +25,16 @@ interface RouteType {
 export interface NaverDrivingResType {
   code: number; // 응답 결과 코드
   route: RouteType; // 응답 결과
+}
+
+export interface DrivingInfoType {
+  start: number[];
+  goal: number[];
+  bbox: number[][];
+  distance: number;
+  duration: number;
+  tollFare: number;
+  taxiFare: number;
+  fuelPrice: number;
+  path: number[][];
 }

--- a/server/src/map/map.response.ts
+++ b/server/src/map/map.response.ts
@@ -1,15 +1,5 @@
 import { failRes, successRes } from '@response/index';
-
-interface DrivingInfoType {
-  start: number[];
-  goal: number[];
-  distance: number;
-  duration: number;
-  tollFare: number;
-  taxiFare: number;
-  fuelPrice: number;
-  path: number[][];
-}
+import { DrivingInfoType } from '@map/map';
 
 export const MAP_RES = {
   SUCCESS_GET_DRIVING_INFO: (data: DrivingInfoType) => {

--- a/server/src/map/map.service.ts
+++ b/server/src/map/map.service.ts
@@ -74,9 +74,9 @@ export class MapService {
    * 길찾기 요청에 대한 summary 정보를 필요한 부분만 사용하고 필요한 형태로 가공
    */
   private summaryDataProcessing(summary: SummaryType) {
-    const { distance, duration, tollFare, taxiFare, fuelPrice } = summary;
+    const { distance, duration, bbox, tollFare, taxiFare, fuelPrice } = summary;
     const start = summary.start.location;
     const goal = summary.goal.location;
-    return { start, goal, distance, duration, tollFare, taxiFare, fuelPrice };
+    return { start, goal, distance, duration, bbox, tollFare, taxiFare, fuelPrice };
   }
 }

--- a/server/src/map/map.service.ts
+++ b/server/src/map/map.service.ts
@@ -74,9 +74,9 @@ export class MapService {
    * 길찾기 요청에 대한 summary 정보를 필요한 부분만 사용하고 필요한 형태로 가공
    */
   private summaryDataProcessing(summary: SummaryType) {
-    const { distance, duration, bbox, tollFare, taxiFare, fuelPrice } = summary;
+    const { distance, duration, tollFare, taxiFare, fuelPrice } = summary;
     const start = summary.start.location;
     const goal = summary.goal.location;
-    return { start, goal, distance, duration, bbox, tollFare, taxiFare, fuelPrice };
+    return { start, goal, distance, duration, tollFare, taxiFare, fuelPrice };
   }
 }


### PR DESCRIPTION
## 링크(관련 이슈)
#72 
<br>

## 개요
길찾기 정보 경로에 알맞게 지도 zoom 레벨을 변경하는 작업

<br>

## 내용
- fitBounds 메서드를 사용해 최적의 경로 표시
- 길찾기 정보 요청시 아무 데이터가 오지 않는다면 toast 메시지를 띄우도록 변경

<br>

## 비고
- [지도 이동하기](https://navermaps.github.io/maps.js.ncp/docs/tutorial-Map.html) 튜토리얼 보니 `fitBounds` 메서드를 사용하면 간단히 해결 가능한 문제였습니다.
  - `fitBounds` 메서드  
    NAVER 지도 API는 내부적으로 좌표 경계를 화면에 표시할 수 있는 최적의 중심 좌표와 줌 레벨을 계산해 지도를 이동

<br>

## 리뷰어한테 할 말
