### PR TITLE
지도의 기본 줌 레벨 수정 16 ->14

### DIFF
--- a/client/src/constants/map.ts
+++ b/client/src/constants/map.ts
@@ -2,4 +2,4 @@ export const NAVER_LAT = 37.358;
 export const NAVER_LNG = 127.1055;
 export const NAVER_ADDRESS = '경기 성남시 분당구 정자일로 95';
 export const MAIN_MAPS_MIN_ZOOM_LEVEL = 7;
-export const DEFAULT_ZOOM = 16;
+export const DEFAULT_ZOOM = 14;


### PR DESCRIPTION
## 링크(관련 이슈)
#191 

<br>

## 개요
메인 맵의 줌 레벨을 수정 16 -> 14
이를 통해 초기 메인 맵 렌더링 시 모임 탐색 반경이 한눈에 들어오게 된다.

<br>

## 내용
- 결과
  
<img width="200" alt="image" src="https://user-images.githubusercontent.com/89074053/207209090-c145707f-56ba-4b6f-8237-f4c67e9edb1c.png">

<br>

## 비고
{ 기타 내용, 의존성있는 작업, 스크린샷 }

<br>

## 리뷰어한테 할 말
{ 집중적으로 리뷰해줬으면 하는 부분 }