### PR TITLE
fix: RestaurantRow 내 버튼이 언마운트될 때 버튼 이벤트를 일괄 삭제하도록 수정

### DIFF
--- a/client/src/components/RestaurantVoteButton/index.tsx
+++ b/client/src/components/RestaurantVoteButton/index.tsx
@@ -56,12 +56,12 @@ function RestaurantVoteButton({
       return;
     }
 
-    socket.on('userVoteRestaurantIdList', (result: VoteRestaurantListType) => {
+    const handleUserVoteRestaurantIdList = (result: VoteRestaurantListType) => {
       votedRestaurantListRef.current = result.data.voteRestaurantIdList;
       setIsVoted(votedRestaurantListRef.current.includes(restaurantId));
-    });
+    }
 
-    socket.on('cancelVoteRestaurantResult', (result: VoteResultType) => {
+    const handleCancelVoteRestaurantResult = (result: VoteResultType) => {
       if (restaurantId !== result.data?.restaurantId) {
         return;
       }
@@ -76,9 +76,9 @@ function RestaurantVoteButton({
         return;
       }
       setIsVoted(false);
-    });
+    }
 
-    socket.on('voteRestaurantResult', (result: VoteResultType) => {
+    const handleVoteRestaurantResult = (result: VoteResultType) => {
       if (restaurantId !== result.data?.restaurantId) {
         return;
       }
@@ -93,9 +93,20 @@ function RestaurantVoteButton({
         return;
       }
       setIsVoted(true);
-    });
+    }
+
+    socket.on('userVoteRestaurantIdList', handleUserVoteRestaurantIdList);
+    socket.on('cancelVoteRestaurantResult', handleCancelVoteRestaurantResult);
+    socket.on('voteRestaurantResult', handleVoteRestaurantResult);
 
     setVotedRestaurantList();
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      socket.removeListener('userVoteRestaurantIdList', handleUserVoteRestaurantIdList);
+      socket.removeListener('voteRestaurantResult', handleVoteRestaurantResult);
+      socket.removeListener('cancelVoteRestaurantResult', handleCancelVoteRestaurantResult);
+    }
   }, []);
 
   const voteRestaurant = () => {


### PR DESCRIPTION
## 링크(관련 이슈)
#198 

<br>

## 개요
현재 RestaurantRow 내 버튼이 마운트될 때 등록되었던 이벤트가 삭제되지 않아 계속해서 이벤트리스너가 쌓이는 문제가 있었습니다. 이에 언마운트될 때 이벤트리스너를 일괄삭제하도록 로직을 변경했습니다.

<br>

## 내용
{ 변경사항(작업내용) }

<br>

## 비고
{ 기타 내용, 의존성있는 작업, 스크린샷 }

<br>

## 리뷰어한테 할 말
{ 집중적으로 리뷰해줬으면 하는 부분 }