### PR TITLE
선택된 식당 정보를, 미리보기와 상세화면에서 공유하며 생기는 오류 수정

### DIFF
--- a/client/src/components/MainMap/index.tsx
+++ b/client/src/components/MainMap/index.tsx
@@ -14,6 +14,7 @@ import {
   useSelectedCategoryStore,
   useMeetLocationStore,
   useSelectedRestaurantDataStore,
+  useSelectedRestaurantPreviewDataStore,
   useMapStore,
 } from '@store/index';
 import { useSocketStore } from '@store/socket';
@@ -81,6 +82,9 @@ function MainMap({ restaurantData, joinList }: PropsType) {
   const { socket } = useSocketStore((state) => state);
   const { updateMap } = useMapStore((state) => state);
   const { meetLocation } = useMeetLocationStore((state) => state);
+  const { updateSelectedRestaurantPreviewData } = useSelectedRestaurantPreviewDataStore(
+    (state) => state
+  );
   const { updateSelectedRestaurantData } = useSelectedRestaurantDataStore((state) => state);
 
   const setMapLocation = (location: LocationType | naver.maps.Coord | null) => {
@@ -309,6 +313,7 @@ function MainMap({ restaurantData, joinList }: PropsType) {
           infoWindow.open(map, marker);
 
           updateSelectedRestaurantData(restaurant);
+          updateSelectedRestaurantPreviewData(restaurant);
 
           map.setCenter(marker.getPosition());
 
@@ -346,7 +351,8 @@ function MainMap({ restaurantData, joinList }: PropsType) {
 
       closeAllRestaurantMarkerInfoWindow();
       closeAllUserMarkerInfoWindow();
-      updateSelectedRestaurantData(null);
+
+      updateSelectedRestaurantPreviewData(null);
     });
     return onDragendListener;
   };

--- a/client/src/components/MainMap/index.tsx
+++ b/client/src/components/MainMap/index.tsx
@@ -87,17 +87,6 @@ function MainMap({ restaurantData, joinList }: PropsType) {
   );
   const { updateSelectedRestaurantData } = useSelectedRestaurantDataStore((state) => state);
 
-  const setMapLocation = (location: LocationType | naver.maps.Coord | null) => {
-    const map = mapRef.current;
-
-    if (!map || !location) {
-      return;
-    }
-
-    map.setCenter(location);
-    map.setZoom(DEFAULT_ZOOM);
-  };
-
   const setMeetingBoundary = (map: naver.maps.Map): void => {
     if (!meetLocation) {
       return;
@@ -327,7 +316,7 @@ function MainMap({ restaurantData, joinList }: PropsType) {
     // map.getCenter() 와 무슨 차이지?
     // map.getCenter() 로 받아온 코드는 갱신이 되질 않는다.
     // 갱신을 위해 map 좌표를 제자리로 이동
-    setMapLocation(map.getBounds().getCenter());
+    map.setCenter(map.getBounds().getCenter());
   };
 
   const onInit = (map: naver.maps.Map): naver.maps.MapEventListener => {
@@ -434,7 +423,13 @@ function MainMap({ restaurantData, joinList }: PropsType) {
 
   // 모임 위치 설정 시 지도 화면 이동
   useEffect(() => {
-    setMapLocation(meetLocation);
+    const map = mapRef.current;
+
+    if (!map || !meetLocation) {
+      return;
+    }
+
+    map.setCenter(meetLocation);
   }, [meetLocation]);
 
   // 사용자의 위치 변경이 있을 경우 반영하는 소켓 이벤트

--- a/client/src/components/MapController/index.tsx
+++ b/client/src/components/MapController/index.tsx
@@ -8,6 +8,8 @@ import useCurrentLocation from '@hooks/useCurrentLocation';
 import { useSocketStore } from '@store/socket';
 import { useMeetLocationStore, useMapStore } from '@store/index';
 
+import { DEFAULT_ZOOM } from '@constants/map';
+
 import { MapControlBox } from './styles';
 
 function MapController() {
@@ -18,6 +20,19 @@ function MapController() {
 
   return (
     <MapControlBox>
+      <button
+        type="button"
+        onClick={() => {
+          if (!map || !meetLocation) {
+            return;
+          }
+
+          map.setCenter(meetLocation);
+          map.setZoom(DEFAULT_ZOOM);
+        }}
+      >
+        <PointCircleIcon />
+      </button>
       <button
         type="button"
         onClick={async () => {
@@ -33,18 +48,6 @@ function MapController() {
         }}
       >
         <GpsIcon />
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          if (!map || !meetLocation) {
-            return;
-          }
-
-          map.setCenter(meetLocation);
-        }}
-      >
-        <PointCircleIcon />
       </button>
     </MapControlBox>
   );

--- a/client/src/components/RestaurantCandidateList/styles.tsx
+++ b/client/src/components/RestaurantCandidateList/styles.tsx
@@ -5,6 +5,7 @@ export const CandidateListModalLayout = styled.div`
   height: 100%;
   padding: 10% 5%;
   background-color: white;
+  overflow-y: scroll;
 `;
 
 export const CandidateListModalBox = styled.div`

--- a/client/src/components/RestaurantPreview/index.tsx
+++ b/client/src/components/RestaurantPreview/index.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef } from 'react';
 import RestaurantRow from '@components/RestaurantRow';
 import { AnimatePresence } from 'framer-motion';
-import { useRestaurantDetailLayerStatusStore, useSelectedRestaurantDataStore } from '@store/index';
+import {
+  useRestaurantDetailLayerStatusStore,
+  useSelectedRestaurantPreviewDataStore,
+} from '@store/index';
 import { RESTAURANT_LIST_TYPES, RESTAURANT_DETAIL_TYPES } from '@constants/modal';
 import { RestaurantPreviewBox, RestaurantPreviewLayout } from './styles';
 
@@ -11,9 +14,8 @@ function RestaurantPreview() {
   const { updateRestaurantDetailLayerStatus } = useRestaurantDetailLayerStatusStore(
     (state) => state
   );
-  const { selectedRestaurantData, updateSelectedRestaurantData } = useSelectedRestaurantDataStore(
-    (state) => state
-  );
+  const { selectedRestaurantPreviewData, updateSelectedRestaurantPreviewData } =
+    useSelectedRestaurantPreviewDataStore((state) => state);
 
   useEffect(() => {
     const modalCloseWindowEvent = (e: Event) => {
@@ -23,7 +25,7 @@ function RestaurantPreview() {
         return;
       }
 
-      updateSelectedRestaurantData(null);
+      updateSelectedRestaurantPreviewData(null);
     };
 
     window.addEventListener('click', modalCloseWindowEvent);
@@ -35,7 +37,7 @@ function RestaurantPreview() {
 
   return (
     <RestaurantPreviewLayout ref={modalRef}>
-      {selectedRestaurantData && (
+      {selectedRestaurantPreviewData && (
         <AnimatePresence>
           <RestaurantPreviewBox
             initial={{ opacity: 0, y: '100%' }}
@@ -49,7 +51,7 @@ function RestaurantPreview() {
             }}
           >
             <RestaurantRow
-              restaurant={selectedRestaurantData}
+              restaurant={selectedRestaurantPreviewData}
               restaurantListType={RESTAURANT_LIST_TYPES.filtered}
             />
           </RestaurantPreviewBox>

--- a/client/src/pages/MainPage/styles.tsx
+++ b/client/src/pages/MainPage/styles.tsx
@@ -94,6 +94,7 @@ export const MapOrListButton = styled.button`
 export const ButtonInnerTextBox = styled.div`
   font-size: 14px;
   font-weight: 500;
+  color: black;
 `;
 
 export const FooterBox = styled.div`

--- a/client/src/store/index.tsx
+++ b/client/src/store/index.tsx
@@ -76,7 +76,8 @@ export const useSelectedRestaurantDataStore = create<SelectedRestaurantDataStore
 /**
  * <선택된 식당 요약정보를 저장하는 저장소>
  * 상세정보 페이지에서 사용되는 SelectedRestaurantDataStore
- * 를 공유할 경우 생기는 문제를 해결하기 위해 만든 저장소입니다.
+ * 를 마커 클릭 시 나오는 미리보기 화면에서도
+ * 함께 사용할 경우 생기는 문제를 해결하기 위해 만든 저장소입니다.
  */
 interface SelectedRestaurantPreviewDataStore {
   selectedRestaurantPreviewData: RestaurantType | null;

--- a/client/src/store/index.tsx
+++ b/client/src/store/index.tsx
@@ -74,6 +74,24 @@ export const useSelectedRestaurantDataStore = create<SelectedRestaurantDataStore
 }));
 
 /**
+ * <선택된 식당 요약정보를 저장하는 저장소>
+ * 상세정보 페이지에서 사용되는 SelectedRestaurantDataStore
+ * 를 공유할 경우 생기는 문제를 해결하기 위해 만든 저장소입니다.
+ */
+interface SelectedRestaurantPreviewDataStore {
+  selectedRestaurantPreviewData: RestaurantType | null;
+  updateSelectedRestaurantPreviewData: (restaurantType: RestaurantType | null) => void;
+}
+
+export const useSelectedRestaurantPreviewDataStore = create<SelectedRestaurantPreviewDataStore>(
+  (set) => ({
+    selectedRestaurantPreviewData: null,
+    updateSelectedRestaurantPreviewData: (restaurantType: RestaurantType | null) =>
+      set(() => ({ selectedRestaurantPreviewData: restaurantType })),
+  })
+);
+
+/**
  * <카테고리 선택정보를 저장하는 전역 저장소>
  * Set이 비어있으면 전체선택을 의미하고,
  * 비어있지 않으면 들어있는 값은 필터링 할 카테고리들을 의미한다.


### PR DESCRIPTION
## 링크(관련 이슈)

- #196 

<br>

## 개요

선택된 식당 정보를, 미리보기와 상세화면에서 공유하며 생기는 오류 수정

<br>

## 내용

미리보기에 사용되는 식당 정보 전역 상태를 하나 더 생성해주는 방법으로 해결했습니다.

식당 미리보기 화면과, 상세화면에 사용되는 데이터를 공유하면서 생긴 문제였으므로, 분리해주는게 제일 깔끔한 방법일 수 도있고, 다른 방법으로 해결할 수 도 있겠지만 시간 상 확실하게 분리했습니다.

### 추가 작업

- 필터링 될 때 기본 zoom 으로 되돌아가는 오류 수정
- 화면에 보이는 식당들만 필터링하여 리스트에 표시
- 모임위치 클릭 시 default zoom level 로 변경되도록 수정
- gps 와 모임위치 버튼 바뀐 부분 수정

<br>

## 비고
{ 기타 내용, 의존성있는 작업, 스크린샷 }

<br>

## 리뷰어한테 할 말
{ 집중적으로 리뷰해줬으면 하는 부분 }