### PR TITLE
모임 생성 시 서버 측 photoUrlList가 Null Safety하지 않았던 부분 수정

### DIFF
--- a/server/src/restaurant/restaurant.service.ts
+++ b/server/src/restaurant/restaurant.service.ts
@@ -135,7 +135,9 @@ export class RestaurantService {
   async getRestaurantDetail(id: string, category: string) {
     const randomRating = getRandomRating();
     try {
-      const { photoUrl: photoUrlList } = await this.restaurantCategoryModel.findOne({ category });
+      const { photoUrl: photoUrlList } = (await this.restaurantCategoryModel.findOne({
+        category,
+      })) ?? { photoUrl: [] };
 
       const photoCnt = photoUrlList.length;
       const selectedPhotoUrlList: string[] = [];


### PR DESCRIPTION
## 링크(관련 이슈)
#208 

<br>

## 개요
이전에 정현님이 언급하셨던 서버 측 에러 메시지에 대한 수정입니다.
<img width="300" alt="image" src="https://user-images.githubusercontent.com/89074053/207758773-12f22c29-21ae-4314-90bc-36cd045b41a2.png">


<br>

## 내용
해당 문제는 서버 측 photoUrlList 변수가 Null Safety하게 짜여지지 않아서 발생한 문제로, 이를 해결했습니다.

<br>

## 비고
{ 기타 내용, 의존성있는 작업, 스크린샷 }

<br>

## 리뷰어한테 할 말
{ 집중적으로 리뷰해줬으면 하는 부분 }