### PR TITLE
redis 비동기 처리 (runtime error 문제해결)

### DIFF
--- a/server/src/socket/socket.gateway.ts
+++ b/server/src/socket/socket.gateway.ts
@@ -253,7 +253,7 @@ export class EventsGateway
 
     // 방안에 같은 세션 접속자가 없을 때 퇴장 처리 (DB, Client 에서 모두 제거)
     if (!roomSessionIDs.includes(sessionID)) {
-      this.redisService.joinList.delUserToJoinList(roomCode, sessionID);
+      await this.redisService.joinList.delUserToJoinList(roomCode, sessionID);
 
       client.to(roomCode).emit('leave', SOCKET_RES.LEAVE_USER(sessionID));
     }


### PR DESCRIPTION
## 링크(관련 이슈)

- #213 

<br>

## 개요

redis에서 비동기 함수를 가져다 사용할 때 비동기 처리를 재대로 해주지 않아 runtime error 가 발생하는 부분을 수정했습니다.

<br>

## 내용

<br>

## 비고

<br>

## 리뷰어한테 할 말
